### PR TITLE
grpcweb/wrapper: use ServeHTTP as the function name

### DIFF
--- a/example/go/exampleserver/exampleserver.go
+++ b/example/go/exampleserver/exampleserver.go
@@ -39,7 +39,7 @@ func main() {
 
 	wrappedServer := grpcweb.WrapServer(grpcServer)
 	handler := func(resp http.ResponseWriter, req *http.Request) {
-		wrappedServer.ServeHttp(resp, req)
+		wrappedServer.ServeHTTP(resp, req)
 	}
 
 	httpServer := http.Server{

--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -155,12 +155,12 @@ func (w *WrappedGrpcServer) IsGrpcWebRequest(req *http.Request) bool
 IsGrpcWebRequest determines if a request is a gRPC-Web request by checking that
 the "content-type" is "application/grpc-web" and that the method is POST.
 
-#### func (*WrappedGrpcServer) ServeHttp
+#### func (*WrappedGrpcServer) ServeHTTP
 
 ```go
-func (w *WrappedGrpcServer) ServeHttp(resp http.ResponseWriter, req *http.Request)
+func (w *WrappedGrpcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request)
 ```
-ServeHttp takes a HTTP request and if it is a gRPC-Web request wraps it with a
+ServeHTTP takes a HTTP request and if it is a gRPC-Web request wraps it with a
 compatibility layer to transform it to a standard gRPC request for the wrapped
 gRPC server and transforms the response to comply with the gRPC-Web protocol.
 

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -47,14 +47,14 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 	}
 }
 
-// ServeHttp takes a HTTP request and if it is a gRPC-Web request wraps it with a compatibility layer to transform it to
+// ServeHTTP takes a HTTP request and if it is a gRPC-Web request wraps it with a compatibility layer to transform it to
 // a standard gRPC request for the wrapped gRPC server and transforms the response to comply with the gRPC-Web protocol.
 //
 // The gRPC-Web compatibility is only invoked if the request is a gRPC-Web request as determined by IsGrpcWebRequest or
 // the request is a pre-flight (CORS) request as determined by IsAcceptableGrpcCorsRequest.
 //
 // You can control the CORS behaviour using `With*` options in the WrapServer function.
-func (w *WrappedGrpcServer) ServeHttp(resp http.ResponseWriter, req *http.Request) {
+func (w *WrappedGrpcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	if w.IsAcceptableGrpcCorsRequest(req) || w.IsGrpcWebRequest(req) {
 		w.corsWrapper.Handler(http.HandlerFunc(w.HandleGrpcWebRequest)).ServeHTTP(resp, req)
 		return

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -71,7 +71,7 @@ func (s *GrpcWebWrapperTestSuite) SetupSuite() {
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			require.EqualValues(s.T(), s.httpMajorVersion, req.ProtoMajor, "Requests in this test are served over the wrong protocol")
 			s.T().Logf("Serving over: %d", req.ProtoMajor)
-			wrappedServer.ServeHttp(resp, req)
+			wrappedServer.ServeHTTP(resp, req)
 		}),
 	}
 

--- a/test/go/testserver/testserver.go
+++ b/test/go/testserver/testserver.go
@@ -14,9 +14,9 @@ import (
 	testproto "../_proto/improbable/grpcweb/test"
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/codes"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/transport"
 )
 
@@ -38,13 +38,13 @@ func main() {
 
 	wrappedServer := grpcweb.WrapServer(grpcServer)
 	handler := func(resp http.ResponseWriter, req *http.Request) {
-		wrappedServer.ServeHttp(resp, req)
+		wrappedServer.ServeHTTP(resp, req)
 	}
 
 	emptyGrpcServer := grpc.NewServer()
 	emptyWrappedServer := grpcweb.WrapServer(emptyGrpcServer, grpcweb.WithCorsForRegisteredEndpointsOnly(false))
 	emptyHandler := func(resp http.ResponseWriter, req *http.Request) {
-		emptyWrappedServer.ServeHttp(resp, req)
+		emptyWrappedServer.ServeHTTP(resp, req)
 	}
 
 	http1Server := http.Server{
@@ -52,7 +52,7 @@ func main() {
 		Handler: http.HandlerFunc(handler),
 	}
 	http1EmptyServer := http.Server{
-		Addr:    fmt.Sprintf(":%d", *http1EmptyPort),
+		Addr: fmt.Sprintf(":%d", *http1EmptyPort),
 		Handler: http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			emptyHandler(res, req)
 		}),


### PR DESCRIPTION
(separate from #28, this might be a breaking change)