### PR TITLE
Updated ts-protoc-gen. Fixes #27

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "concurrently": "^3.4.0",
     "ts-loader": "^2.0.1",
-    "ts-protoc-gen": "^0.2.1",
+    "ts-protoc-gen": "^0.2.2",
     "typescript": "^2.2.1",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.2"

--- a/test/package.json
+++ b/test/package.json
@@ -40,7 +40,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.3",
     "ts-loader": "^2.0.1",
-    "ts-protoc-gen": "^0.2.1",
+    "ts-protoc-gen": "^0.2.2",
     "tslint": "^4.4.2",
     "typescript": "^2.2.1",
     "wd": "^1.2.0",


### PR DESCRIPTION
`ts-protoc-gen` had a bug in `0.2.1` that caused it to error out if the `.proto` file was at the root of the protos directory.

Fixes #27 