### PR TITLE
Add +proto to grpc-web content-type

### DIFF
--- a/ts/src/grpc.ts
+++ b/ts/src/grpc.ts
@@ -171,7 +171,7 @@ export namespace grpc {
 
   export function invoke<TRequest extends jspb.Message, TResponse extends jspb.Message, M extends MethodDefinition<TRequest, TResponse>>(methodDescriptor: M, props: RpcOptions<TRequest, TResponse>) {
     const requestHeaders = new BrowserHeaders(props.metadata ? props.metadata : {});
-    requestHeaders.set("content-type", "application/grpc-web");
+    requestHeaders.set("content-type", "application/grpc-web+proto");
     requestHeaders.set("x-grpc-web", "1"); // Required for CORS handling
 
     const framedRequest = frameRequest(props.request);


### PR DESCRIPTION
My reading of the wire format for both web and native seem to indicate the ```+proto```, etc component is required. As grpc-web currently is tied to proto, it seems safe to just fix the content type to +proto for now.

https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
http://www.grpc.io/docs/guides/wire.html