### PR TITLE
grpcwebproxy: Minor changes to get grpcwebproxy working

### DIFF
--- a/go/grpcwebproxy/backend.go
+++ b/go/grpcwebproxy/backend.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 
 	"github.com/Sirupsen/logrus"
+  "github.com/mwitkow/grpc-proxy/proxy"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -41,6 +42,7 @@ func dialBackendOrFail() *grpc.ClientConn {
 		logrus.Fatalf("flag 'backend_addr' must be set")
 	}
 	opt := []grpc.DialOption{}
+  opt = append(opt, grpc.WithCodec(proxy.Codec()))
 	if *flagBackendIsInsecure {
 		opt = append(opt, grpc.WithInsecure())
 	} else {

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -53,11 +53,7 @@ func main() {
 		WriteTimeout: *flagHttpMaxWriteTimeout,
 		ReadTimeout:  *flagHttpMaxReadTimeout,
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			if wrappedGrpc.IsGrpcWebRequest(req) || wrappedGrpc.IsAcceptableGrpcCorsRequest(req) {
-				wrappedGrpc.HandleGrpcWebRequest(resp, req)
-			}
-			//
-			http.DefaultServeMux.ServeHTTP(resp, req)
+		  wrappedGrpc.ServeHTTP(resp, req)
 		}),
 	}
 	http.Handle("/metrics", promhttp.Handler())
@@ -74,10 +70,7 @@ func main() {
 		WriteTimeout: *flagHttpMaxWriteTimeout,
 		ReadTimeout:  *flagHttpMaxReadTimeout,
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			if wrappedGrpc.IsGrpcWebRequest(req) || wrappedGrpc.IsAcceptableGrpcCorsRequest(req) {
-				wrappedGrpc.HandleGrpcWebRequest(resp, req)
-			}
-			resp.WriteHeader(http.StatusNotImplemented)
+      wrappedGrpc.ServeHTTP(resp, req)
 		}),
 	}
 	servingListener := buildListenerOrFail("http", *flagHttpTlsPort)


### PR DESCRIPTION
- Fixed CORS. OPTIONS request was being processed as a grpc call (main.go).
- Setting proxy.Codec() for backends to correctly serialize requests (backend.go).