### PR TITLE
Node.js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,23 @@
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![quality: alpha](https://img.shields.io/badge/quality-alpha-orange.svg)](#status)
 
-[gRPC](http://www.grpc.io/) is a modern, [HTTP2](https://hpbn.co/http2/)-based protocol, that provides RPC semantics using the strongly-typed *binary* data format of [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview) across multiple languages (C++, C#, Golang, Java, Python, NodeJS, ObjectiveC, etc. [gRPC-Web](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md) is a cutting-edge spec that enables invoking gRPC services from *modern* browsers.
+[gRPC](http://www.grpc.io/) is a modern, [HTTP2](https://hpbn.co/http2/)-based protocol, that provides RPC semantics using the strongly-typed *binary* data format of [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview) across multiple languages (C++, C#, Golang, Java, Python, NodeJS, ObjectiveC, etc. 
+
+[gRPC-Web](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md) is a cutting-edge spec that enables invoking gRPC services from *modern* browsers.
 
 Components of the stack are based on Golang and TypeScript:
  * [`grpcweb`](go/grpcweb) - a Go package that wraps an existing `grpc.Server` as a gRPC-Web `http.Handler` for both HTTP2 and HTTP/1.1
  * [`grpcwebproxy`](go/grpcwebproxy) - a Go-based stand-alone reverse proxy for classic gRPC servers (e.g. in Java or C++) that exposes their services over gRPC-Web to modern browsers
  * [`ts-protoc-gen`](https://github.com/improbable-eng/ts-protoc-gen) - a TypeScript plugin for the protocol buffers compiler that provides strongly typed message classes and method definitions
- * [`grpc-web-client`](ts) - a TypeScript gRPC-Web client library for browsers, not meant to be used directly by users
+ * [`grpc-web-client`](ts) - a TypeScript gRPC-Web client library for browsers ([and Node.js](#Node.js Support)).
 
  
 ## Why?
 
-With gRPC-Web, it is extremely easy to build well defined, easy to reason about APIs between browser frontend code and microservices. Frontend development changes significantly:
+With gRPC-Web, it is extremely easy to build well-defined, easy to reason about APIs between browser frontend code and microservices. Frontend development changes significantly:
  * no more hunting down API documentation - `.proto` is the canonical format for API contracts
  * no more hand-crafted JSON call objects - all requests and responses are strongly typed and code-generated, with hints available in the IDE
- * no more dealing with methods, headers, body and low level networking - everything is handled by `grpc-invoke`
+ * no more dealing with methods, headers, body and low level networking - everything is handled by `grpc.invoke`
  * no more second-guessing the meaning of error codes - [gRPC status codes](https://godoc.org/google.golang.org/grpc/codes) are a canonical way of representing issues in APIs
  * no more one-off server-side request handlers to avoid concurrent connections - gRPC-Web is based on HTTP2, with multiplexes multiple streams over the [same connection](https://hpbn.co/http2/#streams-messages-and-frames)
  * no more problems streaming data from a server -  gRPC-Web supports both *1:1* RPCs and *1:many* streaming requests
@@ -116,7 +118,7 @@ grpc.invoke(BookService.QueryBooks, {
 
 ## Browser Support
 
-The `grpc-web-client` uses multiple techniques to efficiently invoke gRPC services. Most [modern browsers](http://caniuse.com/#feat=fetch) support the [Fetch API](https://developer.mozilla.org/en/docs/Web/API/Fetch_API), which allows for efficient reading of partial, binary responses. For older browsers, it automatically falls back to [`XMLHttpRequest`](https://developer.mozilla.org/nl/docs/Web/API/XMLHttpRequest).
+The `grpc-web-client` uses multiple techniques to efficiently invoke gRPC services. Most modern browsers support the [Fetch API](https://developer.mozilla.org/en/docs/Web/API/Fetch_API), which allows for efficient reading of partial, binary responses. For older browsers, it automatically falls back to [`XMLHttpRequest`](https://developer.mozilla.org/nl/docs/Web/API/XMLHttpRequest).
 
 The gRPC semantics encourage you to make multiple requests at once. With most modern browsers [supporting HTTP2](http://caniuse.com/#feat=http2), these can be executed over a single TLS connection. For older browsers, gRPC-Web falls back to HTTP/1.1 chunk responses.
 
@@ -126,6 +128,12 @@ This library is tested against:
   * Edge >= 13
   * IE >= 11
   * Safari >= 8
+  
+## Node.js Support
+
+`grpc-web-client` also supports Node.js through a transport that uses the `http` and `https` packages. Usage does not vary from browser usage as transport is determined at runtime.
+
+*__Please note - There is an [official Node.js gRPC library](https://github.com/grpc/grpc/tree/9a69478498232b6b42169f8a1a389b51fb4e03ec/src/node) that does not require the server to support gRPC-Web__*
 
 ### Client-side streaming
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+build-node/
+build/

--- a/test/package.json
+++ b/test/package.json
@@ -7,16 +7,19 @@
     "build:proto": "./protogen_go.sh && ./protogen_ts.sh",
     "build:ts": "cd ts && rm -rf build && webpack",
     "build:dev": "cd ts && rm -rf build && webpack --watch",
-    "build": "npm run build:proto && npm run build:testserver && npm run build:ts",
+    "build:node": "cd ts && rm -rf build-node && (cd node-src && tsc) && (cp _proto/improbable/grpcweb/test/test_pb.js build-node/test/ts/_proto/improbable/grpcweb/test/test_pb.js)",
+    "build": "npm run build:proto && npm run build:testserver && npm run build:ts && npm run build:node",
     "lint": "tslint -c ./ts/tslint.json ./ts/src/**/*.ts",
-    "test": "npm run build && ./run-karma.sh ./karma.conf.ts --single-run",
-    "test:dev": "npm run build && ./run-karma.sh ./karma.conf.ts"
+    "test": "npm run build && npm run test:node && npm run test:browser",
+    "test:browser": "./run-testserver.sh karma start ./karma.conf.ts --single-run",
+    "test:node": "./run-testserver.sh jasmine ts/build-node/test/ts/node-src/node.spec.js",
+    "test:dev": "npm run build && ./run-testserver.sh karma start ./karma.conf.ts"
   },
   "license": "none",
   "dependencies": {
     "@types/google-protobuf": "^3.2.5",
     "@types/node": "^7.0.5",
-    "@types/text-encoding": "0.0.30",
+    "browser-headers": "^0.3.2",
     "google-protobuf": "^3.2.0",
     "text-encoding": "^0.6.4",
     "typedarray": "0.0.6"
@@ -32,6 +35,7 @@
     "browserstack-local": "^1.3.0",
     "chai": "^3.5.0",
     "colors": "^1.1.2",
+    "jasmine": "^2.6.0",
     "jasmine-core": "^2.4.1",
     "karma": "^1.2.0",
     "karma-jasmine": "^1.0.2",

--- a/test/run-testserver.sh
+++ b/test/run-testserver.sh
@@ -19,4 +19,4 @@ ps ${SERVER_PID} &> /dev/null
 trap killGoTestServer SIGINT
 trap killGoTestServer EXIT
 
-./node_modules/.bin/karma start $@
+$@

--- a/test/ts/_proto/improbable/grpcweb/test/test_pb.d.ts
+++ b/test/ts/_proto/improbable/grpcweb/test/test_pb.d.ts
@@ -77,7 +77,7 @@ export class PingResponse extends jspb.Message {
 
 export namespace PingResponse {
   export type AsObject = {
-    Value: string,
+    value: string,
     counter: number,
   }
 }

--- a/test/ts/node-src/node.spec.ts
+++ b/test/ts/node-src/node.spec.ts
@@ -1,0 +1,7 @@
+// Allow Node to accept the self-signed certificate
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+// Disable the CORS-related tests as they don't apply for Node environments (no origin)
+process.env.DISABLE_CORS_TESTS = true;
+
+import "../src/grpc.spec";
+import "../src/detach.spec";

--- a/test/ts/node-src/tsconfig.json
+++ b/test/ts/node-src/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "alwaysStrict": true,
     "sourceMap": true,
     "target": "es5",
@@ -9,7 +10,7 @@
     "strictNullChecks": true,
     "stripInternal": true,
     "noFallthroughCasesInSwitch": true,
-    "outDir": "build",
+    "outDir": "../build-node",
     "noEmitOnError": true
   },
   "types": [
@@ -17,6 +18,6 @@
     "node"
   ],
   "include": [
-    "./src"
+    "./node.spec.ts"
   ]
 }

--- a/test/ts/src/util.ts
+++ b/test/ts/src/util.ts
@@ -1,0 +1,57 @@
+export class UncaughtExceptionListener {
+  private attached: boolean = false;
+  private exceptionsCaught: string[] = [];
+  private originalWindowHandler?: ErrorEventHandler;
+  private originalProcessHandlers: Function[] = [];
+  private processListener: (err: Error) => void;
+
+  constructor() {
+    const self = this;
+
+    self.originalWindowHandler = typeof window !== "undefined" ? window.onerror : undefined;
+    self.processListener = (err: Error) => {
+      self.exceptionsCaught.push(err.message);
+    };
+  }
+
+  attach() {
+    const self = this;
+
+    if (self.attached) {
+      return;
+    }
+    if (typeof window !== "undefined") {
+      window.onerror = function (message: string) {
+        self.exceptionsCaught.push(message);
+      };
+    } else {
+      // Remove existing listeners - necessary to prevent test runners from exiting on exceptions
+      self.originalProcessHandlers = process.listeners('uncaughtException');
+      process.removeAllListeners('uncaughtException');
+      process.addListener('uncaughtException', self.processListener);
+    }
+    self.attached = true;
+  }
+
+  detach() {
+    const self = this;
+
+    if (!self.attached) {
+      return;
+    }
+    if (typeof window !== "undefined") {
+      window.onerror = self.originalWindowHandler!;
+    } else {
+      process.removeListener('uncaughtException', self.processListener);
+      self.originalProcessHandlers.forEach(handler => {
+        process.addListener('uncaughtException', handler);
+      });
+      self.originalProcessHandlers = [];
+    }
+    self.attached = false;
+  }
+
+  getMessages() {
+    return this.exceptionsCaught;
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -30,12 +30,15 @@
     "google-protobuf": "^3.2.0"
   },
   "dependencies": {
-    "browser-headers": "^0.2.1"
+    "@types/text-encoding": "0.0.30",
+    "browser-headers": "^0.2.1",
+    "text-encoding": "^0.6.4"
   },
   "devDependencies": {
     "@types/google-protobuf": "^3.2.5",
+    "@types/node": "^7.0.29",
+    "google-protobuf": "^3.2.0",
     "tslint": "^4.5.1",
-    "typescript": "^2.2.1",
-    "google-protobuf": "^3.2.0"
+    "typescript": "^2.2.1"
   }
 }

--- a/ts/src/ChunkParser.ts
+++ b/ts/src/ChunkParser.ts
@@ -1,4 +1,5 @@
 import {BrowserHeaders} from "browser-headers";
+import * as TextEncoding from "text-encoding";
 
 const HEADER_SIZE = 5;
 
@@ -10,7 +11,8 @@ function isTrailerHeader(headerView: DataView) {
 }
 
 function parseTrailerData(msgData: Uint8Array): BrowserHeaders {
-  return new BrowserHeaders(new global.TextDecoder("utf-8").decode(msgData))
+  const decoder = global.TextDecoder !== undefined ? global.TextDecoder : TextEncoding.TextDecoder;
+  return new BrowserHeaders(new decoder("utf-8").decode(msgData))
 }
 
 function readLengthFromHeader(headerView: DataView) {

--- a/ts/src/grpc.ts
+++ b/ts/src/grpc.ts
@@ -259,8 +259,8 @@ export namespace grpc {
             const deserialized = methodDescriptor.responseType.deserializeBinary(d.data!);
             rawOnMessage(deserialized);
           } else if (d.chunkType === ChunkType.TRAILERS) {
-            props.debug && debug("onChunk.trailers", responseTrailers);
             responseTrailers = new BrowserHeaders(d.trailers);
+            props.debug && debug("onChunk.trailers", responseTrailers);
           }
         });
       },

--- a/ts/src/transports/Transport.ts
+++ b/ts/src/transports/Transport.ts
@@ -2,6 +2,7 @@ import {BrowserHeaders} from "browser-headers";
 import fetchRequest from "./fetch";
 import xhrRequest from "./xhr";
 import mozXhrRequest from "./mozXhr";
+import httpNodeTransport from "./nodeHttp";
 
 declare const Response: any;
 declare const Headers: any;
@@ -65,12 +66,18 @@ export class DefaultTransportFactory {
       return fetchRequest;
     }
 
-    if (xhrSupportsResponseType("moz-chunked-arraybuffer")) {
-      return mozXhrRequest;
+    if (typeof XMLHttpRequest !== "undefined") {
+      if (xhrSupportsResponseType("moz-chunked-arraybuffer")) {
+        return mozXhrRequest;
+      }
+
+      if (XMLHttpRequest.prototype.hasOwnProperty("overrideMimeType")) {
+        return xhrRequest;
+      }
     }
 
-    if (XMLHttpRequest.prototype.hasOwnProperty("overrideMimeType")) {
-      return xhrRequest;
+    if (typeof module !== "undefined" && module.exports) {
+      return httpNodeTransport;
     }
 
     throw new Error("No suitable transport found for gRPC-Web");

--- a/ts/src/transports/nodeHttp.ts
+++ b/ts/src/transports/nodeHttp.ts
@@ -1,0 +1,70 @@
+import * as http from 'http';
+import * as https from 'https';
+import * as url from 'url';
+import {TransportOptions} from "./Transport";
+import {BrowserHeaders} from "browser-headers";
+
+/* nodeHttpRequest uses the node http and https modules */
+export default function nodeHttpRequest(options: TransportOptions) {
+  options.debug && console.log('httpNodeTransport', options);
+
+  const headers: { [key: string]: string } = {};
+  options.headers.forEach((key, values) => {
+    headers[key] = values.join(', ');
+  });
+
+  const parsedUrl = url.parse(options.url);
+
+  const httpOptions = {
+    host: parsedUrl.hostname,
+    port: parsedUrl.port ? parseInt(parsedUrl.port) : undefined,
+    path: parsedUrl.path,
+    headers: headers,
+    method: 'POST'
+  };
+
+  const responseCallback = (response: http.IncomingMessage) => {
+    options.debug && console.log('httpNodeTransport.response', response.statusCode);
+    options.onHeaders(new BrowserHeaders(response.headers), response.statusCode!);
+
+    response.on('data', chunk => {
+      options.debug && console.log('httpNodeTransport.data', chunk);
+      options.onChunk(toArrayBuffer(chunk as Buffer));
+    });
+
+    response.on('end', () => {
+      options.debug && console.log('httpNodeTransport.end');
+      options.onEnd();
+    });
+  };
+
+  let request;
+  if (parsedUrl.protocol === "https:") {
+    request = https.request(httpOptions, responseCallback);
+  } else {
+    request = http.request(httpOptions, responseCallback);
+  }
+  request.on('error', err => {
+    options.debug && console.log('httpNodeTransport.error', err);
+    options.onEnd(err);
+  });
+  request.write(toBuffer(options.body));
+  request.end();
+}
+
+function toArrayBuffer(buf: Buffer): Uint8Array {
+  const view = new Uint8Array(buf.length);
+  for (let i = 0; i < buf.length; i++) {
+    view[i] = buf[i];
+  }
+  return view;
+}
+
+function toBuffer(ab: ArrayBufferView): Buffer {
+  const buf = new Buffer(ab.byteLength);
+  const view = new Uint8Array(ab.buffer);
+  for (let i = 0; i < buf.length; i++) {
+    buf[i] = view[i];
+  }
+  return buf;
+}


### PR DESCRIPTION
I've added support for Node.js using Node's `http` and `https` modules as initially requested in #53.

This required a refactor of test setup and addition of the `text-encoding` package.

The library is currently only tested with Webpack (and now Node.js). It's possible this change has broken other environments due to one of the transports requiring node-only modules.

@HTChang, can you confirm that this approach works?