### PR TITLE
Send cookies to same origin with fetch transport to have same behavio…

### DIFF
--- a/ts/src/transports/fetch.ts
+++ b/ts/src/transports/fetch.ts
@@ -26,6 +26,7 @@ export default function fetchRequest(options: TransportOptions) {
     headers: options.headers.toHeaders(),
     method: "POST",
     body: options.body,
+    credentials: "same-origin",
   }).then((res: Response) => {
     options.debug && debug("fetchRequest.response", res);
     detach(() => {


### PR DESCRIPTION
…r among all transports.

While it might be useful to have an option, it would be a bit weird since the option would only have an effect on the fetch transport, not xhr transports. Let me know if an option would still be preferable.

While most gRPC APIs themselves shouldn't rely on cookies for state per good API design, it's still useful to send them from browsers since many proxies rely on them for things like corp-authentication (I'm using GCP's Identity-Aware Proxy) and sticky sessions.