### PR TITLE
Deny CORS requests by default

### DIFF
--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -98,7 +98,7 @@ mechanism allows you to limit the availability of the APIs based on the domain
 name of the calling website (Origin). You can provide a function that filters
 the allowed Origin values.
 
-The default behaviour is `*`, i.e. to allow all calling websites.
+The default behaviour is to deny all requests from remote origins.
 
 The relevant CORS pre-flight docs:
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -7,7 +7,7 @@ var (
 	defaultOptions = &options{
 		allowedRequestHeaders:          []string{"*"},
 		corsForRegisteredEndpointsOnly: true,
-		originFunc:                     func(origin string) bool { return true },
+		originFunc:                     func(origin string) bool { return false },
 	}
 )
 
@@ -34,7 +34,7 @@ type Option func(*options)
 // availability of the APIs based on the domain name of the calling website (Origin). You can provide a function that
 // filters the allowed Origin values.
 //
-// The default behaviour is `*`, i.e. to allow all calling websites.
+// The default behaviour is to deny all requests from remote origins.
 //
 // The relevant CORS pre-flight docs:
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -50,6 +50,8 @@ type GrpcWebWrapperTestSuite struct {
 	suite.Suite
 	httpMajorVersion int
 	listener         net.Listener
+	grpcServer       *grpc.Server
+	wrappedServer    *grpcweb.WrappedGrpcServer
 }
 
 func TestHttp2GrpcWebWrapperTestSuite(t *testing.T) {
@@ -60,18 +62,18 @@ func TestHttp1GrpcWebWrapperTestSuite(t *testing.T) {
 	suite.Run(t, &GrpcWebWrapperTestSuite{httpMajorVersion: 1})
 }
 
-func (s *GrpcWebWrapperTestSuite) SetupSuite() {
+func (s *GrpcWebWrapperTestSuite) SetupTest() {
 	var err error
-	grpcServer := grpc.NewServer()
-	testproto.RegisterTestServiceServer(grpcServer, &testServiceImpl{})
+	s.grpcServer = grpc.NewServer()
+	testproto.RegisterTestServiceServer(s.grpcServer, &testServiceImpl{})
 	grpclog.SetLogger(log.New(os.Stderr, "grpc: ", log.LstdFlags))
-	wrappedServer := grpcweb.WrapServer(grpcServer)
+	s.wrappedServer = grpcweb.WrapServer(s.grpcServer)
 
 	httpServer := http.Server{
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			require.EqualValues(s.T(), s.httpMajorVersion, req.ProtoMajor, "Requests in this test are served over the wrong protocol")
 			s.T().Logf("Serving over: %d", req.ProtoMajor)
-			wrappedServer.ServeHTTP(resp, req)
+			s.wrappedServer.ServeHTTP(resp, req)
 		}),
 	}
 
@@ -253,7 +255,7 @@ func (s *GrpcWebWrapperTestSuite) TestPingList_NormalGrpcWorks() {
 	assert.EqualValues(s.T(), expectedTrailers, trailerMd, "expected trailers must be received")
 }
 
-func (s *GrpcWebWrapperTestSuite) TestCORSPreflight() {
+func (s *GrpcWebWrapperTestSuite) TestCORSPreflight_DeniedByDefault() {
 	/**
 	OPTIONS /improbable.grpcweb.test.TestService/Ping
 	Access-Control-Request-Method: POST
@@ -269,10 +271,39 @@ func (s *GrpcWebWrapperTestSuite) TestCORSPreflight() {
 	assert.NoError(s.T(), err, "cors preflight should not return errors")
 
 	preflight := corsResp.Header
-	assert.Equal(s.T(), "http://foo.client.com", preflight.Get("Access-Control-Allow-Origin"), "origin must be in the preflight")
-	assert.Equal(s.T(), "POST", preflight.Get("Access-Control-Allow-Methods"), "allowed methods must be in the preflight")
-	assert.Equal(s.T(), "600", preflight.Get("Access-Control-Max-Age"), "allowed max age must be in the response")
-	assert.Equal(s.T(), "Origin, X-Something-Custom, X-Grpc-Web, Accept", preflight.Get("Access-Control-Allow-Headers"), "allowed max age must be in the response")
+	assert.Equal(s.T(), "", preflight.Get("Access-Control-Allow-Origin"), "origin must not be in the response headers")
+	assert.Equal(s.T(), "", preflight.Get("Access-Control-Allow-Methods"), "allowed methods must not be in the response headers")
+	assert.Equal(s.T(), "", preflight.Get("Access-Control-Max-Age"), "allowed max age must not be in the response headers")
+	assert.Equal(s.T(), "", preflight.Get("Access-Control-Allow-Headers"), "allowed max age must not be in the response headers")
+}
+
+func (s *GrpcWebWrapperTestSuite) TestCORSPreflight_AllowedByOriginFunc() {
+	/**
+	OPTIONS /improbable.grpcweb.test.TestService/Ping
+	Access-Control-Request-Method: POST
+	Access-Control-Request-Headers: origin, x-requested-with, accept
+	Origin: http://foo.client.com
+	*/
+	headers := http.Header{}
+	headers.Add("Access-Control-Request-Method", "POST")
+	headers.Add("Access-Control-Request-Headers", "origin, x-something-custom, x-grpc-web, accept")
+	headers.Add("Origin", "http://foo.client.com")
+
+	// Create a new server which permits Cross-Origin Resource requests from `foo.client.com`
+	s.wrappedServer = grpcweb.WrapServer(s.grpcServer,
+		grpcweb.WithOriginFunc(func(origin string) bool {
+			return origin == "http://foo.client.com"
+		}),
+	)
+
+	corsResp, err := s.makeRequest("OPTIONS", "/improbable.grpcweb.test.TestService/PingList", headers, nil)
+	assert.NoError(s.T(), err, "cors preflight should not return errors")
+
+	preflight := corsResp.Header
+	assert.Equal(s.T(), "http://foo.client.com", preflight.Get("Access-Control-Allow-Origin"), "origin must be in the response headers")
+	assert.Equal(s.T(), "POST", preflight.Get("Access-Control-Allow-Methods"), "allowed methods must be in the response headers")
+	assert.Equal(s.T(), "600", preflight.Get("Access-Control-Max-Age"), "allowed max age must be in the response headers")
+	assert.Equal(s.T(), "Origin, X-Something-Custom, X-Grpc-Web, Accept", preflight.Get("Access-Control-Allow-Headers"), "allowed max age must be in the response headers")
 }
 
 func (s *GrpcWebWrapperTestSuite) assertHeadersContainMetadata(headers http.Header, meta metadata.MD) {

--- a/go/grpcwebproxy/backend.go
+++ b/go/grpcwebproxy/backend.go
@@ -5,8 +5,8 @@ import (
 	"crypto/x509"
 	"io/ioutil"
 
-	"github.com/sirupsen/logrus"
 	"github.com/mwitkow/grpc-proxy/proxy"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -11,7 +11,6 @@ import (
 
 	"crypto/tls"
 
-	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -19,6 +18,7 @@ import (
 	"github.com/mwitkow/go-conntrack"
 	"github.com/mwitkow/grpc-proxy/proxy"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
 	_ "golang.org/x/net/trace" // register in DefaultServerMux
@@ -45,8 +45,11 @@ func main() {
 	grpcServer := buildGrpcProxyServer(logEntry)
 	errChan := make(chan error)
 
-	// gRPC-Web compatibility layer with CORS configured to accept on every
-	wrappedGrpc := grpcweb.WrapServer(grpcServer, grpcweb.WithCorsForRegisteredEndpointsOnly(false))
+	// gRPC-Web compatibility layer with CORS configured to accept on every request
+	wrappedGrpc := grpcweb.WrapServer(grpcServer,
+		grpcweb.WithCorsForRegisteredEndpointsOnly(false),
+		grpcweb.WithOriginFunc(func(origin string) bool { return true }),
+	)
 
 	// Debug server.
 	debugServer := http.Server{

--- a/go/grpcwebproxy/server_tls.go
+++ b/go/grpcwebproxy/server_tls.go
@@ -3,8 +3,8 @@ package main
 import (
 	"crypto/tls"
 
-	logrus "github.com/sirupsen/logrus"
 	"github.com/mwitkow/go-conntrack/connhelpers"
+	logrus "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"crypto/x509"

--- a/test/go/testserver/testserver.go
+++ b/test/go/testserver/testserver.go
@@ -38,13 +38,21 @@ func main() {
 	testproto.RegisterTestServiceServer(grpcServer, &testSrv{})
 	grpclog.SetLogger(log.New(os.Stdout, "testserver: ", log.LstdFlags))
 
-	wrappedServer := grpcweb.WrapServer(grpcServer)
+	allowAllOrigins := grpcweb.WithOriginFunc(func(origin string) bool {
+		return true
+	})
+
+	wrappedServer := grpcweb.WrapServer(grpcServer, allowAllOrigins)
 	handler := func(resp http.ResponseWriter, req *http.Request) {
 		wrappedServer.ServeHTTP(resp, req)
 	}
 
 	emptyGrpcServer := grpc.NewServer()
-	emptyWrappedServer := grpcweb.WrapServer(emptyGrpcServer, grpcweb.WithCorsForRegisteredEndpointsOnly(false))
+	emptyWrappedServer := grpcweb.WrapServer(
+	    emptyGrpcServer,
+	    allowAllOrigins,
+	    grpcweb.WithCorsForRegisteredEndpointsOnly(false),
+	)
 	emptyHandler := func(resp http.ResponseWriter, req *http.Request) {
 		emptyWrappedServer.ServeHTTP(resp, req)
 	}


### PR DESCRIPTION
Change the default implementation of grpcweb.WrapServer so it denies requests from foreign origins by default to avoid circumventing the browser security model.

See discussion in #61.