### PR TITLE
Change wrapped server to a http.Handler

### DIFF
--- a/go/grpcweb/helpers.go
+++ b/go/grpcweb/helpers.go
@@ -5,8 +5,6 @@ package grpcweb
 
 import (
 	"fmt"
-
-	"google.golang.org/grpc"
 )
 
 // ListGRPCResources is a helper function that lists all URLs that are registered on gRPC server.

--- a/go/grpcweb/helpers.go
+++ b/go/grpcweb/helpers.go
@@ -12,7 +12,7 @@ import (
 // ListGRPCResources is a helper function that lists all URLs that are registered on gRPC server.
 //
 // This makes it easy to register all the relevant routes in your HTTP router of choice.
-func ListGRPCResources(server *grpc.Server) []string {
+func ListGRPCResources(server GrpcServer) []string {
 	ret := []string{}
 	for serviceName, serviceInfo := range server.GetServiceInfo() {
 		for _, methodInfo := range serviceInfo.Methods {

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/rs/cors"
-	"google.golang.org/grpc"
 )
 
 var (
@@ -20,7 +19,7 @@ var (
 )
 
 type WrappedGrpcServer struct {
-	server      *grpc.Server
+	server      http.Handler
 	opts        *options
 	corsWrapper *cors.Cors
 }
@@ -31,7 +30,7 @@ type WrappedGrpcServer struct {
 // http.ResponseWriter, i.e. mostly the re-encoding of Trailers (that carry gRPC status).
 //
 // You can control the behaviour of the wrapper (e.g. modifying CORS behaviour) using `With*` options.
-func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
+func WrapServer(server http.Handler, options ...Option) *WrappedGrpcServer {
 	opts := evaluateOptions(options)
 	corsWrapper := cors.New(cors.Options{
 		AllowOriginFunc:  opts.originFunc,

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -19,9 +19,14 @@ var (
 )
 
 type WrappedGrpcServer struct {
-	server      http.Handler
+	server      GrpcServer
 	opts        *options
 	corsWrapper *cors.Cors
+}
+
+type GrpcServer interface {
+	http.Handler
+	GetServiceInfo() map[string]ServiceInfo
 }
 
 // WrapServer takes a gRPC Server in Go and returns a WrappedGrpcServer that provides gRPC-Web Compatibility.
@@ -30,7 +35,7 @@ type WrappedGrpcServer struct {
 // http.ResponseWriter, i.e. mostly the re-encoding of Trailers (that carry gRPC status).
 //
 // You can control the behaviour of the wrapper (e.g. modifying CORS behaviour) using `With*` options.
-func WrapServer(server http.Handler, options ...Option) *WrappedGrpcServer {
+func WrapServer(server GrpcServer, options ...Option) *WrappedGrpcServer {
 	opts := evaluateOptions(options)
 	corsWrapper := cors.New(cors.Options{
 		AllowOriginFunc:  opts.originFunc,


### PR DESCRIPTION
This allows the wrapped server to be used in a composable manner with other Go handlers.