### PR TITLE
Fix compilation of tests with TS _proto generated services

### DIFF
--- a/test/ts/webpack.config.ts
+++ b/test/ts/webpack.config.ts
@@ -16,7 +16,7 @@ module.exports = {
       },
       {
         test: /\.ts$/,
-        include: /src/,
+        include: [/src/, /_proto/],
         exclude: /node_modules/,
         loader: "ts-loader"
       }


### PR DESCRIPTION
When running the tests, webpack throws an error as it cannot find any loader for files generated under the `_proto` directory. This is caused by only matching the `ts-loader` in webpack against `src`. 

This MR fixes the problem by allowing webpack to use the `ts-loader` for files under both `src` and `_proto` directories.

Interestingly enough, this does not seem to happen on the CI.

The error generated is shown below:
```
ERROR in ./_proto/improbable/grpcweb/test/test_pb_service.ts
Module parse failed: /Users/easy/_programming/grpc-web-ofc/test/ts/_proto/improbable/grpcweb/test/test_pb_service.ts Unexpected token (7:21)
You may need an appropriate loader to handle this file type.
| import * as google_protobuf_empty_pb from "google-protobuf/google/protobuf/empty_pb";
| export class TestService {
|   static serviceName = "improbable.grpcweb.test.TestService";
| }
| export namespace TestService {
 @ ./src/grpc.spec.ts 31:24-84
 @ ./src/spec.ts
```

