### PR TITLE
Add grpcweb to get_go_deps.sh

### DIFF
--- a/example/get_go_deps.sh
+++ b/example/get_go_deps.sh
@@ -1,3 +1,4 @@
+go get github.com/improbable-eng/grpc-web/go/grpcweb
 go get github.com/sirupsen/logrus
 go get github.com/grpc-ecosystem/go-grpc-prometheus
 go get github.com/mwitkow/go-conntrack


### PR DESCRIPTION
Running `npm start` in the example project failed because `grpcweb` had never been installed into my go workspace. This pull request will fix that issue for future users.