### PR TITLE
nodeHttp: explicitly set Content-Length

### DIFF
--- a/ts/src/transports/Transport.ts
+++ b/ts/src/transports/Transport.ts
@@ -7,7 +7,7 @@ import {MethodDefinition} from "../service";
 import {ProtobufMessage} from "../message";
 
 export interface Transport {
-  sendMessage(msgBytes: ArrayBufferView): void
+  sendMessage(msgBytes: Uint8Array): void
   finishSend(): void
   cancel(): void
   start(metadata: Metadata): void

--- a/ts/src/transports/fetch.ts
+++ b/ts/src/transports/fetch.ts
@@ -44,7 +44,7 @@ class Fetch implements Transport {
       });
   }
 
-  send(msgBytes: ArrayBufferView) {
+  send(msgBytes: Uint8Array) {
     fetch(this.options.url, {
       headers: this.metadata.toHeaders(),
       method: "POST",
@@ -71,7 +71,7 @@ class Fetch implements Transport {
     });
   }
 
-  sendMessage(msgBytes: ArrayBufferView) {
+  sendMessage(msgBytes: Uint8Array) {
     this.send(msgBytes);
   }
 

--- a/ts/src/transports/mozXhr.ts
+++ b/ts/src/transports/mozXhr.ts
@@ -47,7 +47,7 @@ class MozXHR implements Transport {
     }
   }
 
-  sendMessage(msgBytes: ArrayBufferView) {
+  sendMessage(msgBytes: Uint8Array) {
     this.options.debug && debug("MozXHR.sendMessage");
     this.xhr.send(msgBytes);
   }

--- a/ts/src/transports/nodeHttp.ts
+++ b/ts/src/transports/nodeHttp.ts
@@ -19,7 +19,7 @@ class NodeHttp implements Transport {
     this.options = transportOptions;
   }
 
-  sendMessage(msgBytes: ArrayBufferView) {
+  sendMessage(msgBytes: Uint8Array) {
     this.request.write(toBuffer(msgBytes));
     this.request.end();
   }
@@ -46,7 +46,7 @@ class NodeHttp implements Transport {
 
   start(metadata: Metadata) {
     const headers: { [key: string]: string } = {
-      'Content-Length': options.body.length.toString()
+      "Content-Length": options.body.length.toString()
     };
     metadata.forEach((key, values) => {
       headers[key] = values.join(", ");
@@ -100,7 +100,7 @@ function toArrayBuffer(buf: Buffer): Uint8Array {
   return view;
 }
 
-function toBuffer(ab: ArrayBufferView): Buffer {
+function toBuffer(ab: Uint8Array): Buffer {
   const buf = new Buffer(ab.byteLength);
   const view = new Uint8Array(ab.buffer);
   for (let i = 0; i < buf.length; i++) {

--- a/ts/src/transports/nodeHttp.ts
+++ b/ts/src/transports/nodeHttp.ts
@@ -45,7 +45,9 @@ class NodeHttp implements Transport {
   };
 
   start(metadata: Metadata) {
-    const headers: { [key: string]: string } = {};
+    const headers: { [key: string]: string } = {
+      'Content-Length': options.body.length.toString()
+    };
     metadata.forEach((key, values) => {
       headers[key] = values.join(", ");
     });

--- a/ts/src/transports/xhr.ts
+++ b/ts/src/transports/xhr.ts
@@ -47,7 +47,7 @@ class XHR implements Transport {
     }
   }
 
-  sendMessage(msgBytes: ArrayBufferView) {
+  sendMessage(msgBytes: Uint8Array) {
     this.xhr.send(msgBytes);
   }
 

--- a/ts/src/util.ts
+++ b/ts/src/util.ts
@@ -1,6 +1,6 @@
 import {ProtobufMessage} from "./message";
 
-export function frameRequest(request: ProtobufMessage): ArrayBufferView {
+export function frameRequest(request: ProtobufMessage): Uint8Array {
   const bytes = request.serializeBinary();
   const frame = new ArrayBuffer(bytes.byteLength + 5);
   new DataView(frame, 1, 4).setUint32(0, bytes.length, false /* big endian */);


### PR DESCRIPTION
This is to avoid unnecessarily making the requests chunked, which are not needed as we don't support client-side streaming yet.

Ref: GAE's frontend is too retarded to handle chunked encoding. https://issuetracker.google.com/issues/71003088