### PR TITLE
Add flags to control which servers run

### DIFF
--- a/go/grpcwebproxy/README.md
+++ b/go/grpcwebproxy/README.md
@@ -34,3 +34,15 @@ $GOPATH/bin/grpcwebproxy
     --backend_addr=localhost:9090 \
     --backend_tls_noverify
 ```
+
+### Running specific servers
+
+By default, grpcwebproxy will run both TLS and HTTP debug servers. To disable either one, set the `--run_http_server` or `--run_tls_server` flags to false.
+
+For example, to only run the HTTP server, run the following:
+
+```
+$GOPATH/bin/grpcwebproxy
+    --backend_addr=localhost:9090 \
+    --run_tls_server=false
+```

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -28,8 +28,8 @@ import (
 
 var (
 	flagBindAddr    = pflag.String("server_bind_address", "0.0.0.0", "address to bind the server to")
-	flagHttpPort    = pflag.Int("server_http_debug_port", 8080, "TCP port to listen on for HTTP1.1 debug calls. If 0, no insecure HTTP will be open.")
-	flagHttpTlsPort = pflag.Int("server_http_tls_port", 8443, "TCP port to listen on for HTTPS (gRPC, gRPC-Web). If 0, no TLS will be open.")
+	flagHttpPort    = pflag.Int("server_http_debug_port", 8080, "TCP port to listen on for HTTP1.1 debug calls.")
+	flagHttpTlsPort = pflag.Int("server_http_tls_port", 8443, "TCP port to listen on for HTTPS (gRPC, gRPC-Web).")
 
 	runHttpServer = pflag.Bool("run_http_server", true, "whether to run HTTP server")
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -71,8 +71,8 @@ func main() {
 	// TODO(mwitkow): Add graceful shutdown.
 }
 
-func buildServer(wrappedGrpc *grpcweb.WrappedGrpcServer) http.Server {
-	return http.Server{
+func buildServer(wrappedGrpc *grpcweb.WrappedGrpcServer) *http.Server {
+	return &http.Server{
 		WriteTimeout: *flagHttpMaxWriteTimeout,
 		ReadTimeout:  *flagHttpMaxReadTimeout,
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
@@ -81,7 +81,7 @@ func buildServer(wrappedGrpc *grpcweb.WrappedGrpcServer) http.Server {
 	}
 }
 
-func serveServer(server http.Server, listener net.Listener, name string, errChan chan error) {
+func serveServer(server *http.Server, listener net.Listener, name string, errChan chan error) {
 	go func() {
 		logrus.Infof("listening for %s on: %v", name, listener.Addr().String())
 		if err := server.Serve(listener); err != nil {

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -11,8 +11,11 @@ import (
 
 	"crypto/tls"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
+	"github.com/mwitkow/go-conntrack"
 	"github.com/mwitkow/grpc-proxy/proxy"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -21,9 +24,6 @@ import (
 	_ "golang.org/x/net/trace" // register in DefaultServerMux
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/mwitkow/go-conntrack"
 )
 
 var (
@@ -31,13 +31,15 @@ var (
 	flagHttpPort    = pflag.Int("server_http_debug_port", 8080, "TCP port to listen on for HTTP1.1 debug calls. If 0, no insecure HTTP will be open.")
 	flagHttpTlsPort = pflag.Int("server_http_tls_port", 8443, "TCP port to listen on for HTTPS (gRPC, gRPC-Web). If 0, no TLS will be open.")
 
+	runHttpServer = pflag.Bool("run_http_server", true, "whether to run HTTP server")
+	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
+
 	flagHttpMaxWriteTimeout = pflag.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = pflag.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
 )
 
 func main() {
 	pflag.Parse()
-	serverTls := buildServerTlsOrFail()
 
 	logrus.SetOutput(os.Stdout)
 
@@ -49,39 +51,44 @@ func main() {
 	// gRPC-Web compatibility layer with CORS configured to accept on every
 	wrappedGrpc := grpcweb.WrapServer(grpcServer, grpcweb.WithCorsForRegisteredEndpointsOnly(false))
 
-	// Debug server.
-	debugServer := http.Server{
-		WriteTimeout: *flagHttpMaxWriteTimeout,
-		ReadTimeout:  *flagHttpMaxReadTimeout,
-		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			wrappedGrpc.ServeHTTP(resp, req)
-		}),
-	}
-	http.Handle("/metrics", promhttp.Handler())
-	debugListener := buildListenerOrFail("http", *flagHttpPort)
-	go func() {
-		logrus.Infof("listening for http on: %v", debugListener.Addr().String())
-		if err := debugServer.Serve(debugListener); err != nil {
-			errChan <- fmt.Errorf("http_debug server error: %v", err)
+	if *runHttpServer {
+		// Debug server.
+		debugServer := http.Server{
+			WriteTimeout: *flagHttpMaxWriteTimeout,
+			ReadTimeout:  *flagHttpMaxReadTimeout,
+			Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				wrappedGrpc.ServeHTTP(resp, req)
+			}),
 		}
-	}()
+		http.Handle("/metrics", promhttp.Handler())
+		debugListener := buildListenerOrFail("http", *flagHttpPort)
+		go func() {
+			logrus.Infof("listening for http on: %v", debugListener.Addr().String())
+			if err := debugServer.Serve(debugListener); err != nil {
+				errChan <- fmt.Errorf("http_debug server error: %v", err)
+			}
+		}()
+	}
 
-	// Debug server.
-	servingServer := http.Server{
-		WriteTimeout: *flagHttpMaxWriteTimeout,
-		ReadTimeout:  *flagHttpMaxReadTimeout,
-		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			wrappedGrpc.ServeHTTP(resp, req)
-		}),
-	}
-	servingListener := buildListenerOrFail("http", *flagHttpTlsPort)
-	servingListener = tls.NewListener(servingListener, serverTls)
-	go func() {
-		logrus.Infof("listening for http_tls on: %v", servingListener.Addr().String())
-		if err := servingServer.Serve(servingListener); err != nil {
-			errChan <- fmt.Errorf("http_tls server error: %v", err)
+	if *runTlsServer {
+		// Debug server.
+		servingServer := http.Server{
+			WriteTimeout: *flagHttpMaxWriteTimeout,
+			ReadTimeout:  *flagHttpMaxReadTimeout,
+			Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				wrappedGrpc.ServeHTTP(resp, req)
+			}),
 		}
-	}()
+		servingListener := buildListenerOrFail("http", *flagHttpTlsPort)
+		servingListener = tls.NewListener(servingListener, buildServerTlsOrFail())
+		go func() {
+			logrus.Infof("listening for http_tls on: %v", servingListener.Addr().String())
+			if err := servingServer.Serve(servingListener); err != nil {
+				errChan <- fmt.Errorf("http_tls server error: %v", err)
+			}
+		}()
+	}
+
 	<-errChan
 	// TODO(mwitkow): Add graceful shutdown.
 }


### PR DESCRIPTION
The issue https://github.com/improbable-eng/grpc-web/issues/31 is still not completely fixed in eda5103aa449bf449977da5879189f9b74940b23. The server still defaults to running HTTP and TLS servers without any way of disabling either one of them them.

I have added the `run_http_server` and `run_tls_server` flags, giving developers more control over which server they wish to run.