### PR TITLE
Update browser headers to version 0.4

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@types/text-encoding": "0.0.30",
-    "browser-headers": "^0.2.1",
+    "browser-headers": "^0.4.0",
     "text-encoding": "^0.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The new version contains a fix needed to make work grpc-web-client with the grpc-web envoy proxy.