### PR TITLE
Fix ts errors by updating grpc web client version

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@types/google-protobuf": "^3.2.5",
     "google-protobuf": "^3.2.0",
-    "grpc-web-client": "0.4.0"
+    "grpc-web-client": "0.5.0"
   },
   "devDependencies": {
     "concurrently": "^3.4.0",


### PR DESCRIPTION
Due to a major refactoring of the typescript client code between 0.4.0 and 0.5.0, the example project typescript code was *updated* but there needs to be a corresponding module version bump in order to clear up some syntax errors. This commit fixes `npm start` for the example.