### PR TITLE
Fix error in debug log message

### DIFF
--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -216,7 +216,7 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
   }
 
   rawOnMessage(res: TResponse) {
-    this.props.debug && debug("rawOnMessage", res.toObject());
+    this.props.debug && debug("rawOnMessage", res);
     if (this.completed) return;
     this.onMessageCallbacks.forEach(callback => {
       detach(() => {


### PR DESCRIPTION
In my testing of https://github.com/improbable-eng/grpc-web/pull/137/files I ran into an instance of this where `res` did not have a function called `toObject`. This fix removes that assumption, though my understanding of TypeScript is that it shouldn't be possible in the first place? I experienced this on Firefox 59.