### PR TITLE
Make gRPC status codes consistent with gRPC-Go

### DIFF
--- a/test/ts/src/client.spec.ts
+++ b/test/ts/src/client.spec.ts
@@ -378,7 +378,7 @@ describe(`client`, () => {
             DEBUG && debug("status", status, "statusMessage", statusMessage, "trailers", trailers);
             // Some browsers return empty Headers for failed requests
             assert.strictEqual(statusMessage, "Response closed without headers");
-            assert.strictEqual(status, grpc.Code.Internal);
+            assert.strictEqual(status, grpc.Code.Unknown);
             assert.ok(!didGetOnMessage);
             done();
           });
@@ -411,7 +411,7 @@ describe(`client`, () => {
         client.onEnd((status: grpc.Code, statusMessage: string, trailers: grpc.Metadata) => {
           DEBUG && debug("status", status, "statusMessage", statusMessage, "trailers", trailers);
           assert.strictEqual(statusMessage, "Response closed without grpc-status (Headers only)");
-          assert.strictEqual(status, grpc.Code.Internal);
+          assert.strictEqual(status, grpc.Code.Unknown);
           assert.ok(!didGetOnMessage);
           done();
         });
@@ -440,7 +440,7 @@ describe(`client`, () => {
         client.onEnd((status: grpc.Code, statusMessage: string, trailers: grpc.Metadata) => {
           DEBUG && debug("status", status, "statusMessage", statusMessage, "trailers", trailers);
           assert.strictEqual(statusMessage, "Response closed without headers");
-          assert.strictEqual(status, grpc.Code.Internal);
+          assert.strictEqual(status, grpc.Code.Unknown);
           assert.ok(!didGetOnMessage);
           done();
         });

--- a/test/ts/src/invoke.spec.ts
+++ b/test/ts/src/invoke.spec.ts
@@ -338,7 +338,7 @@ describe("invoke", () => {
               DEBUG && debug("status", status, "statusMessage", statusMessage, "trailers", trailers);
               // Some browsers return empty Headers for failed requests
               assert.strictEqual(statusMessage, "Response closed without headers");
-              assert.strictEqual(status, grpc.Code.Internal);
+              assert.strictEqual(status, grpc.Code.Unknown);
               assert.ok(!didGetOnMessage);
               done();
             }
@@ -370,7 +370,7 @@ describe("invoke", () => {
           onEnd: (status: grpc.Code, statusMessage: string, trailers: grpc.Metadata) => {
             DEBUG && debug("status", status, "statusMessage", statusMessage, "trailers", trailers);
             assert.strictEqual(statusMessage, "Response closed without grpc-status (Headers only)");
-            assert.strictEqual(status, grpc.Code.Internal);
+            assert.strictEqual(status, grpc.Code.Unknown);
             assert.ok(!didGetOnMessage);
             done();
           }
@@ -398,7 +398,7 @@ describe("invoke", () => {
           onEnd: (status: grpc.Code, statusMessage: string, trailers: grpc.Metadata) => {
             DEBUG && debug("status", status, "statusMessage", statusMessage, "trailers", trailers);
             assert.strictEqual(statusMessage, "Response closed without headers");
-            assert.strictEqual(status, grpc.Code.Internal);
+            assert.strictEqual(status, grpc.Code.Unknown);
             assert.ok(!didGetOnMessage);
             done();
           }

--- a/test/ts/src/unary.spec.ts
+++ b/test/ts/src/unary.spec.ts
@@ -213,7 +213,7 @@ describe(`unary`, () => {
               DEBUG && debug("status", status, "statusMessage", statusMessage, "headers", headers, "res", message, "trailers", trailers);
               // Some browsers return empty Headers for failed requests
               assert.strictEqual(statusMessage, "Response closed without headers");
-              assert.strictEqual(status, grpc.Code.Internal);
+              assert.strictEqual(status, grpc.Code.Unknown);
               done();
             }
           });
@@ -232,7 +232,7 @@ describe(`unary`, () => {
           onEnd: ({status, statusMessage, headers, message, trailers}) => {
             DEBUG && debug("status", status, "statusMessage", statusMessage, "headers", headers, "res", message, "trailers", trailers);
             assert.strictEqual(statusMessage, "Response closed without grpc-status (Headers only)");
-            assert.strictEqual(status, grpc.Code.Internal);
+            assert.strictEqual(status, grpc.Code.Unknown);
             assert.deepEqual(headers.get("grpc-status"), []);
             assert.deepEqual(headers.get("grpc-message"), []);
             done();
@@ -252,7 +252,7 @@ describe(`unary`, () => {
           onEnd: ({status, statusMessage, headers, message, trailers}) => {
             DEBUG && debug("status", status, "statusMessage", statusMessage, "headers", headers, "res", message, "trailers", trailers);
             assert.strictEqual(statusMessage, "Response closed without headers");
-            assert.strictEqual(status, grpc.Code.Internal);
+            assert.strictEqual(status, grpc.Code.Unknown);
             assert.isNull(message);
             done();
           }

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -151,7 +151,7 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
     if (this.responseTrailers === undefined) {
       if (this.responseHeaders === undefined) {
         // The request was unsuccessful - it did not receive any headers
-        this.rawOnError(Code.Internal, "Response closed without headers");
+        this.rawOnError(Code.Unknown, "Response closed without headers");
         return;
       }
 
@@ -162,7 +162,7 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
       this.props.debug && debug("grpc.headers only response ", grpcStatus, grpcMessage);
 
       if (grpcStatus === null) {
-        this.rawOnEnd(Code.Internal, "Response closed without grpc-status (Headers only)", this.responseHeaders);
+        this.rawOnEnd(Code.Unknown, "Response closed without grpc-status (Headers only)", this.responseHeaders);
         return;
       }
 


### PR DESCRIPTION
This changes the two status errors that can be returned during network errors to `codes.Unknown`, which is consistent with the gRPC-Go client implementation.

Fixes #149