### PR TITLE
Deny CORS Requests by Default

### DIFF
--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -40,6 +40,14 @@ on gRPC server.
 This makes it easy to register all the relevant routes in your HTTP router of
 choice.
 
+#### func  WebsocketRequestOrigin
+
+```go
+func WebsocketRequestOrigin(req *http.Request) (string, error)
+```
+WebsocketRequestOrigin returns the host from which a websocket request made by a
+web browser originated.
+
 #### type Option
 
 ```go
@@ -98,7 +106,7 @@ mechanism allows you to limit the availability of the APIs based on the domain
 name of the calling website (Origin). You can provide a function that filters
 the allowed Origin values.
 
-The default behaviour is `*`, i.e. to allow all calling websites.
+The default behaviour is to deny all requests from remote origins.
 
 The relevant CORS pre-flight docs:
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
@@ -112,7 +120,7 @@ WithWebsocketOriginFunc allows for customizing the acceptance of Websocket
 requests - usually to check that the origin is valid.
 
 The default behaviour is to check that the origin of the request matches the
-host of the request.
+host of the request and deny all requests from remote origins.
 
 #### func  WithWebsockets
 

--- a/go/grpcweb/helpers.go
+++ b/go/grpcweb/helpers.go
@@ -6,6 +6,9 @@ package grpcweb
 import (
 	"fmt"
 
+	"net/http"
+	"net/url"
+
 	"google.golang.org/grpc"
 )
 
@@ -21,4 +24,15 @@ func ListGRPCResources(server *grpc.Server) []string {
 		}
 	}
 	return ret
+}
+
+// WebsocketRequestOrigin returns the host from which a websocket request made by a web browser
+// originated.
+func WebsocketRequestOrigin(req *http.Request) (string, error) {
+	origin := req.Header.Get("Origin")
+	url, err := url.ParseRequestURI(origin)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse url for grpc-websocket origin check: %s. error: %v", origin, err)
+	}
+	return url.Host, nil
 }

--- a/go/grpcweb/helpers.go
+++ b/go/grpcweb/helpers.go
@@ -5,7 +5,6 @@ package grpcweb
 
 import (
 	"fmt"
-
 	"net/http"
 	"net/url"
 
@@ -30,9 +29,9 @@ func ListGRPCResources(server *grpc.Server) []string {
 // originated.
 func WebsocketRequestOrigin(req *http.Request) (string, error) {
 	origin := req.Header.Get("Origin")
-	url, err := url.ParseRequestURI(origin)
+	parsed, err := url.ParseRequestURI(origin)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse url for grpc-websocket origin check: %s. error: %v", origin, err)
+		return "", fmt.Errorf("failed to parse url for grpc-websocket origin check: %q. error: %v", origin, err)
 	}
-	return url.Host, nil
+	return parsed.Host, nil
 }

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -9,7 +9,7 @@ var (
 	defaultOptions = &options{
 		allowedRequestHeaders:          []string{"*"},
 		corsForRegisteredEndpointsOnly: true,
-		originFunc:                     func(origin string) bool { return true },
+		originFunc:                     func(origin string) bool { return false },
 	}
 )
 
@@ -38,7 +38,7 @@ type Option func(*options)
 // availability of the APIs based on the domain name of the calling website (Origin). You can provide a function that
 // filters the allowed Origin values.
 //
-// The default behaviour is `*`, i.e. to allow all calling websites.
+// The default behaviour is to deny all requests from remote origins.
 //
 // The relevant CORS pre-flight docs:
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
@@ -93,7 +93,7 @@ func WithWebsockets(enableWebsockets bool) Option {
 // WithWebsocketOriginFunc allows for customizing the acceptance of Websocket requests - usually to check that the origin
 // is valid.
 //
-// The default behaviour is to check that the origin of the request matches the host of the request.
+// The default behaviour is to check that the origin of the request matches the host of the request and deny all requests from remote origins.
 func WithWebsocketOriginFunc(websocketOriginFunc func(req *http.Request) bool) Option {
 	return func(o *options) {
 		o.websocketOriginFunc = websocketOriginFunc

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -55,15 +54,7 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 	})
 	websocketOriginFunc := opts.websocketOriginFunc
 	if websocketOriginFunc == nil {
-		websocketOriginFunc = func(req *http.Request) bool {
-			origin := req.Header.Get("Origin")
-			parsedUrl, err := url.ParseRequestURI(origin)
-			if err != nil {
-				grpclog.Warningf("Unable to parse url for grpc-websocket origin check: %s. error: %v", origin, err)
-				return false
-			}
-			return parsedUrl.Host == req.Host
-		}
+		websocketOriginFunc = defaultWebsocketOriginFunc
 	}
 	return &WrappedGrpcServer{
 		server:              server,
@@ -235,4 +226,13 @@ func hackIntoNormalGrpcRequest(req *http.Request) (*http.Request, bool) {
 	req.Header.Set("content-type", strings.Replace(contentType, incomingContentType, grpcContentType, 1))
 
 	return req, isTextFormat
+}
+
+func defaultWebsocketOriginFunc(req *http.Request) bool {
+	origin, err := WebsocketRequestOrigin(req)
+	if err != nil {
+		grpclog.Warning(err)
+		return false
+	}
+	return origin == req.Host
 }

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -50,6 +50,8 @@ type GrpcWebWrapperTestSuite struct {
 	suite.Suite
 	httpMajorVersion int
 	listener         net.Listener
+	grpcServer       *grpc.Server
+	wrappedServer    *grpcweb.WrappedGrpcServer
 }
 
 func TestHttp2GrpcWebWrapperTestSuite(t *testing.T) {
@@ -60,18 +62,18 @@ func TestHttp1GrpcWebWrapperTestSuite(t *testing.T) {
 	suite.Run(t, &GrpcWebWrapperTestSuite{httpMajorVersion: 1})
 }
 
-func (s *GrpcWebWrapperTestSuite) SetupSuite() {
+func (s *GrpcWebWrapperTestSuite) SetupTest() {
 	var err error
-	grpcServer := grpc.NewServer()
-	testproto.RegisterTestServiceServer(grpcServer, &testServiceImpl{})
+	s.grpcServer = grpc.NewServer()
+	testproto.RegisterTestServiceServer(s.grpcServer, &testServiceImpl{})
 	grpclog.SetLogger(log.New(os.Stderr, "grpc: ", log.LstdFlags))
-	wrappedServer := grpcweb.WrapServer(grpcServer)
+	s.wrappedServer = grpcweb.WrapServer(s.grpcServer)
 
 	httpServer := http.Server{
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			require.EqualValues(s.T(), s.httpMajorVersion, req.ProtoMajor, "Requests in this test are served over the wrong protocol")
 			s.T().Logf("Serving over: %d", req.ProtoMajor)
-			wrappedServer.ServeHTTP(resp, req)
+			s.wrappedServer.ServeHTTP(resp, req)
 		}),
 	}
 
@@ -87,6 +89,8 @@ func (s *GrpcWebWrapperTestSuite) SetupSuite() {
 	go func() {
 		httpServer.Serve(s.listener)
 	}()
+
+	// Wait for the grpcServer to start serving requests.
 	time.Sleep(10 * time.Millisecond)
 }
 
@@ -349,7 +353,7 @@ func (s *GrpcWebWrapperTestSuite) TestPingStream_NormalGrpcWorks() {
 	assert.EqualValues(s.T(), expectedTrailers, recvTrailers, "expected trailers must be received")
 }
 
-func (s *GrpcWebWrapperTestSuite) TestCORSPreflight() {
+func (s *GrpcWebWrapperTestSuite) TestCORSPreflight_DeniedByDefault() {
 	/**
 	OPTIONS /improbable.grpcweb.test.TestService/Ping
 	Access-Control-Request-Method: POST
@@ -359,16 +363,45 @@ func (s *GrpcWebWrapperTestSuite) TestCORSPreflight() {
 	headers := http.Header{}
 	headers.Add("Access-Control-Request-Method", "POST")
 	headers.Add("Access-Control-Request-Headers", "origin, x-something-custom, x-grpc-web, accept")
-	headers.Add("Origin", "http://foo.client.com")
+	headers.Add("Origin", "https://foo.client.com")
 
 	corsResp, err := s.makeRequest("OPTIONS", "/improbable.grpcweb.test.TestService/PingList", headers, nil, false)
 	assert.NoError(s.T(), err, "cors preflight should not return errors")
 
 	preflight := corsResp.Header
-	assert.Equal(s.T(), "http://foo.client.com", preflight.Get("Access-Control-Allow-Origin"), "origin must be in the preflight")
-	assert.Equal(s.T(), "POST", preflight.Get("Access-Control-Allow-Methods"), "allowed methods must be in the preflight")
-	assert.Equal(s.T(), "600", preflight.Get("Access-Control-Max-Age"), "allowed max age must be in the response")
-	assert.Equal(s.T(), "Origin, X-Something-Custom, X-Grpc-Web, Accept", preflight.Get("Access-Control-Allow-Headers"), "allowed max age must be in the response")
+	assert.Equal(s.T(), "", preflight.Get("Access-Control-Allow-Origin"), "origin must not be in the response headers")
+	assert.Equal(s.T(), "", preflight.Get("Access-Control-Allow-Methods"), "allowed methods must not be in the response headers")
+	assert.Equal(s.T(), "", preflight.Get("Access-Control-Max-Age"), "allowed max age must not be in the response headers")
+	assert.Equal(s.T(), "", preflight.Get("Access-Control-Allow-Headers"), "allowed headers must not be in the response headers")
+}
+
+func (s *GrpcWebWrapperTestSuite) TestCORSPreflight_AllowedByOriginFunc() {
+	/**
+	OPTIONS /improbable.grpcweb.test.TestService/Ping
+	Access-Control-Request-Method: POST
+	Access-Control-Request-Headers: origin, x-requested-with, accept
+	Origin: http://foo.client.com
+	*/
+	headers := http.Header{}
+	headers.Add("Access-Control-Request-Method", "POST")
+	headers.Add("Access-Control-Request-Headers", "origin, x-something-custom, x-grpc-web, accept")
+	headers.Add("Origin", "https://foo.client.com")
+
+	// Create a new server which permits Cross-Origin Resource requests from `foo.client.com`.
+	s.wrappedServer = grpcweb.WrapServer(s.grpcServer,
+		grpcweb.WithOriginFunc(func(origin string) bool {
+			return origin == "https://foo.client.com"
+		}),
+	)
+
+	corsResp, err := s.makeRequest("OPTIONS", "/improbable.grpcweb.test.TestService/PingList", headers, nil, false)
+	assert.NoError(s.T(), err, "cors preflight should not return errors")
+
+	preflight := corsResp.Header
+	assert.Equal(s.T(), "https://foo.client.com", preflight.Get("Access-Control-Allow-Origin"), "origin must be in the response headers")
+	assert.Equal(s.T(), "POST", preflight.Get("Access-Control-Allow-Methods"), "allowed methods must be in the response headers")
+	assert.Equal(s.T(), "600", preflight.Get("Access-Control-Max-Age"), "allowed max age must be in the response headers")
+	assert.Equal(s.T(), "Origin, X-Something-Custom, X-Grpc-Web, Accept", preflight.Get("Access-Control-Allow-Headers"), "allowed headers must be in the response headers")
 }
 
 func (s *GrpcWebWrapperTestSuite) assertHeadersContainMetadata(headers http.Header, meta metadata.MD) {

--- a/go/grpcwebproxy/README.md
+++ b/go/grpcwebproxy/README.md
@@ -80,3 +80,21 @@ grpcwebproxy \
 ```
 
 Note that if you set a lower value than 4MB, the lower value will be used. Also, it is preferrable to send data in a stream than to set a very large value.
+
+### Configuring CORS for Http and WebSocket connections
+
+By default, grpcwebproxy will reject any request originating from a client running on any domain other than that of where the server is hosted, this can be configured via one of the `--allow_all_origins` or `--allowed_origins` flags.
+
+For example, to allow requests from any origin:
+
+```bash
+grpcwebproxy \
+    --allow_all_origins
+```
+
+Or to only allow requests from a specific list of origins:
+
+```bash
+grpcwebproxy \
+    --allowed_origins=https://example.org,https://awesome.com
+```

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 	_ "golang.org/x/net/trace" // register in DefaultServerMux
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -30,6 +31,9 @@ var (
 	flagBindAddr    = pflag.String("server_bind_address", "0.0.0.0", "address to bind the server to")
 	flagHttpPort    = pflag.Int("server_http_debug_port", 8080, "TCP port to listen on for HTTP1.1 debug calls.")
 	flagHttpTlsPort = pflag.Int("server_http_tls_port", 8443, "TCP port to listen on for HTTPS (gRPC, gRPC-Web).")
+
+	flagAllowAllOrigins = pflag.Bool("allow_all_origins", false, "allow requests from any origin.")
+	flagAllowedOrigins  = pflag.StringSlice("allowed_origins", nil, "list of origin URLs which are allowed to make cross-origin requests.")
 
 	runHttpServer = pflag.Bool("run_http_server", true, "whether to run HTTP server")
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
@@ -44,24 +48,28 @@ func main() {
 	pflag.Parse()
 
 	logrus.SetOutput(os.Stdout)
-
 	logEntry := logrus.NewEntry(logrus.StandardLogger())
+
+	if *flagAllowAllOrigins && len(*flagAllowedOrigins) != 0 {
+		logrus.Fatal("Ambiguous --allow_all_origins and --allow_origins configuration. Either set --allow_all_origins=true OR specify one or more origins to whitelist with --allow_origins, not both.")
+	}
 
 	grpcServer := buildGrpcProxyServer(logEntry)
 	errChan := make(chan error)
 
+	allowedOrigins := makeAllowedOrigins(*flagAllowedOrigins)
+
 	options := []grpcweb.Option{
-		// gRPC-Web compatibility layer with CORS configured to accept on every request
 		grpcweb.WithCorsForRegisteredEndpointsOnly(false),
+		grpcweb.WithOriginFunc(makeHttpOriginFunc(allowedOrigins)),
 	}
+
 	if *useWebsockets {
 		logrus.Println("using websockets")
 		options = append(
 			options,
 			grpcweb.WithWebsockets(true),
-			grpcweb.WithWebsocketOriginFunc(func(req *http.Request) bool {
-				return true
-			}),
+			grpcweb.WithWebsocketOriginFunc(makeWebsocketOriginFunc(allowedOrigins)),
 		)
 	}
 	wrappedGrpc := grpcweb.WrapServer(grpcServer, options...)
@@ -150,4 +158,52 @@ func buildListenerOrFail(name string, port int) net.Listener {
 		conntrack.TrackWithTcpKeepAlive(20*time.Second),
 		conntrack.TrackWithTracing(),
 	)
+}
+
+func makeHttpOriginFunc(allowedOrigins *allowedOrigins) func(origin string) bool {
+	if *flagAllowAllOrigins {
+		return func(origin string) bool {
+			return true
+		}
+	} else {
+		return func(origin string) bool {
+			return allowedOrigins.IsAllowed(origin)
+		}
+	}
+}
+
+func makeWebsocketOriginFunc(allowedOrigins *allowedOrigins) func(req *http.Request) bool {
+	if *flagAllowAllOrigins {
+		return func(req *http.Request) bool {
+			return true
+		}
+	} else {
+		return func(req *http.Request) bool {
+			origin, err := grpcweb.WebsocketRequestOrigin(req)
+			if err != nil {
+				grpclog.Warning(err)
+				return false
+			}
+			return allowedOrigins.IsAllowed(origin)
+		}
+	}
+}
+
+func makeAllowedOrigins(origins []string) *allowedOrigins {
+	allowedOrigins := map[string]struct{}{}
+	for _, allowedOrigin := range origins {
+		allowedOrigins[allowedOrigin] = struct{}{}
+	}
+	return &allowedOrigins{
+		origins: allowedOrigins,
+	}
+}
+
+type allowedOrigins struct {
+	origins map[string]struct{}
+}
+
+func (a *allowedOrigins) IsAllowed(origin string) bool {
+	_, ok := a.origins[origin]
+	return ok
 }

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -33,7 +33,7 @@ var (
 	flagHttpTlsPort = pflag.Int("server_http_tls_port", 8443, "TCP port to listen on for HTTPS (gRPC, gRPC-Web).")
 
 	flagAllowAllOrigins = pflag.Bool("allow_all_origins", false, "allow requests from any origin.")
-	flagAllowedOrigins  = pflag.StringSlice("allowed_origins", nil, "list of origin URLs which are allowed to make cross-origin requests.")
+	flagAllowedOrigins  = pflag.StringSlice("allowed_origins", nil, "comma-separated list of origin URLs which are allowed to make cross-origin requests.")
 
 	runHttpServer = pflag.Bool("run_http_server", true, "whether to run HTTP server")
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
@@ -165,11 +165,8 @@ func makeHttpOriginFunc(allowedOrigins *allowedOrigins) func(origin string) bool
 		return func(origin string) bool {
 			return true
 		}
-	} else {
-		return func(origin string) bool {
-			return allowedOrigins.IsAllowed(origin)
-		}
 	}
+	return allowedOrigins.IsAllowed
 }
 
 func makeWebsocketOriginFunc(allowedOrigins *allowedOrigins) func(req *http.Request) bool {

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -190,12 +190,12 @@ func makeWebsocketOriginFunc(allowedOrigins *allowedOrigins) func(req *http.Requ
 }
 
 func makeAllowedOrigins(origins []string) *allowedOrigins {
-	allowedOrigins := map[string]struct{}{}
+	o := map[string]struct{}{}
 	for _, allowedOrigin := range origins {
-		allowedOrigins[allowedOrigin] = struct{}{}
+		o[allowedOrigin] = struct{}{}
 	}
 	return &allowedOrigins{
-		origins: allowedOrigins,
+		origins: o,
 	}
 }
 

--- a/integration_test/go/testserver/testserver.go
+++ b/integration_test/go/testserver/testserver.go
@@ -45,14 +45,28 @@ func main() {
 	websocketOriginFunc := grpcweb.WithWebsocketOriginFunc(func(req *http.Request) bool {
 		return true
 	})
+	httpOriginFunc := grpcweb.WithOriginFunc(func(origin string) bool {
+		return true
+	})
 
-	wrappedServer := grpcweb.WrapServer(grpcServer, grpcweb.WithWebsockets(true), websocketOriginFunc)
+	wrappedServer := grpcweb.WrapServer(
+		grpcServer,
+		grpcweb.WithWebsockets(true),
+		httpOriginFunc,
+		websocketOriginFunc,
+	)
 	handler := func(resp http.ResponseWriter, req *http.Request) {
 		wrappedServer.ServeHTTP(resp, req)
 	}
 
 	emptyGrpcServer := grpc.NewServer()
-	emptyWrappedServer := grpcweb.WrapServer(emptyGrpcServer, grpcweb.WithWebsockets(true), websocketOriginFunc, grpcweb.WithCorsForRegisteredEndpointsOnly(false))
+	emptyWrappedServer := grpcweb.WrapServer(
+		emptyGrpcServer,
+		grpcweb.WithWebsockets(true),
+		grpcweb.WithCorsForRegisteredEndpointsOnly(false),
+		httpOriginFunc,
+		websocketOriginFunc,
+	)
 	emptyHandler := func(resp http.ResponseWriter, req *http.Request) {
 		emptyWrappedServer.ServeHTTP(resp, req)
 	}


### PR DESCRIPTION
Change the default implementation of `grpcweb.WrapServer` so it denies requests from foreign origins by default to avoid circumventing the browser security model.

See discussion in #61.