### PR TITLE
Feature/lint go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,9 @@ before_install:
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJfU1RBQ0tfQUNDRVNTX0tFWT1SRG1Cc2pwQUJ4RlljcEVkeVp5bwo=`
 install:
   - go get -u github.com/golang/dep/cmd/dep
-  - go get github.com/golang/protobuf/protoc-gen-go
+  - go get -u golang.org/x/tools/cmd/goimports
+  - go get -u github.com/robertkrimen/godocdown/godocdown
+  - go get -u github.com/golang/protobuf/protoc-gen-go
   - dep ensure
   - export PATH=/home/travis/gopath/src/github.com/improbable-eng/grpc-web/protobuf/bin:$PATH
   - nvm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,4 @@ install:
 before_script:
   - ./test/start-testserver.sh &
 script:
-  - travis_retry npm run test
+  - travis_retry ./test-all.sh

--- a/go/checkup.sh
+++ b/go/checkup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Script that checks up code (govet).
 
+set -e
+
 function print_real_go_files {
     grep --files-without-match 'DO NOT EDIT!' $(find . -iname '*.go')
 }

--- a/go/checkup.sh
+++ b/go/checkup.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 # Script that checks up code (govet).
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-
 function print_real_go_files {
     grep --files-without-match 'DO NOT EDIT!' $(find . -iname '*.go')
 }
 
 function govet_all {
+    echo "Running govet"
     ret=0
     for i in $(print_real_go_files); do
         output=$(go tool vet -all=true -tests=false ${i})

--- a/go/fixup.sh
+++ b/go/fixup.sh
@@ -8,24 +8,37 @@ function print_real_go_files {
 }
 
 function generate_markdown {
-    echo "Generating markdown"
+    echo "Generating markdown using godocdown in..."
     oldpwd=$(pwd)
     for i in $(find . -iname 'doc.go'); do
         dir=${i%/*}
-        echo "$dir"
+        echo "- $dir"
         cd ${dir}
         ${GOPATH}/bin/godocdown -heading=Title -o DOC.md
         ln -s DOC.md README.md 2> /dev/null # can fail
         cd ${oldpwd}
     done;
+
+    git diff --name-only --exit-code | grep -q DOC.md
+    if [[ $? -ne 1 ]]; then
+      echo "ERROR: Documentation changes detected, please commit them."
+      exit 1
+    fi
+}
+
+function check_no_documentation_changes {
+  echo "Checking generated documentation is up to date"
+
 }
 
 function goimports_all {
     echo "Running goimports"
-    goimports -l -w $(print_real_go_files)
-    return $?
+    ${GOPATH}/bin/goimports -l -w $(print_real_go_files)
+    if [[ $? -ne 0 ]]; then
+      echo "ERROR: goimports changes detected, please commit them."
+      exit 1
+    fi
 }
 
 generate_markdown
 goimports_all
-echo "returning $?"

--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -1,7 +1,6 @@
 # grpcweb
-```go
-import "github.com/improbable-eng/grpc-web/go/grpcweb"
-```
+--
+    import "github.com/improbable-eng/grpc-web/go/grpcweb"
 
 `grpcweb` implements the gRPC-Web spec as a wrapper around a gRPC-Go Server.
 
@@ -53,7 +52,7 @@ type Option func(*options)
 ```go
 func WithAllowedRequestHeaders(headers []string) Option
 ```
-WithAllowedResponseHeaders allows for customizing what gRPC request headers a
+WithAllowedRequestHeaders allows for customizing what gRPC request headers a
 browser can add.
 
 This is controlling the CORS pre-flight `Access-Control-Allow-Headers` method

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -463,5 +463,4 @@ func (s *testServiceImpl) PingPongBidi(stream testproto.TestService_PingPongBidi
 			}
 		}
 	}
-	return nil
 }

--- a/test-all.sh
+++ b/test-all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Linting go sources"
+pushd ./go
+./checkup.sh
+./fixup.sh
+popd
+
+echo "Running tests"
+npm run test


### PR DESCRIPTION
Run `go/fixup.sh` and `go/checkup.sh` scripts on each build to ensure that code is lint free and the autogenerated documentation is up to date.