### PR TITLE
Keep original headers

### DIFF
--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -148,12 +148,16 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 		return
 	}
 
+	// Overwrite original request headers with those we parsed out.
+	for k := range headers {
+		req.Header.Set(k, headers.Get(k))
+	}
+
 	respWriter := newWebSocketResponseWriter(wsConn)
 	wrappedReader := newWebsocketWrappedReader(wsConn, respWriter)
 
 	req.Body = wrappedReader
 	req.Method = http.MethodPost
-	req.Header = headers
 	req.ProtoMajor = 2
 	req.ProtoMinor = 0
 	contentType := req.Header.Get("content-type")


### PR DESCRIPTION
I was giving this project a shot and have to say it's pretty nice doing JS -> grpc. 

I don't know if this is the right approach here but there are custom headers that I would like to expose to grpc metadata so that in an interceptor I can access these values (for example JWT).

This allows headers to propagate all the way down rather than being overwritten. Let me know if there's a better way to handle this.