### PR TITLE
Removed Node transport from automatic detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,14 @@ This library is tested against:
   
 ## Node.js Support
 
-`grpc-web-client` also [supports Node.js through a transport](ts/docs/transport.md#node-http-only-available-in-a-nodejs-environment) that uses the `http` and `https` packages. Usage does not vary from browser usage as transport is determined at runtime.
+`grpc-web-client` also [supports Node.js through a transport](ts/docs/transport.md#node-http-only-available-in-a-nodejs-environment) that uses the `http` and `https` packages. In order to ensure the library is tree-shakable, you must explicitly import and specify the Node transport like so:
+
+```
+import nodeHttpRequest from "grpc-web-client/dist/transports/nodeHttp";
+grpc.unary(BookService.QueryBooks, {
+  transport: nodeHttpRequest
+});
+```
 
 If you want to use `grpc-web-client` in a node.js environment with Typescript, you must include `dom` in the `"lib"` Array in your `tsconfig.json` otherwise `tsc` will be unable to find some type declarations to compile. Note that `dom` will be included automatically if you do not declare `lib` in your configration and your target is one of `es5` or `es6`. (See [Typescript compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)).
 

--- a/ts/src/transports/Transport.ts
+++ b/ts/src/transports/Transport.ts
@@ -2,7 +2,6 @@ import {Metadata} from "../metadata";
 import fetchRequest, {detectFetchSupport} from "./fetch";
 import xhrRequest, {detectXHRSupport} from "./xhr";
 import mozXhrRequest, {detectMozXHRSupport} from "./mozXhr";
-import httpNodeRequest, {detectNodeHTTPSupport} from "./nodeHttp";
 import {MethodDefinition} from "../service";
 import {ProtobufMessage} from "../message";
 import websocketRequest from "./websocket";
@@ -54,11 +53,8 @@ function detectTransport(): TransportConstructor {
     return xhrRequest;
   }
 
-  if (detectNodeHTTPSupport()) {
-    return httpNodeRequest;
-  }
-
-  throw new Error("No suitable transport found for gRPC-Web");
+  throw new Error("No suitable transport found for gRPC-Web.  If running in " +
+    "Node, import and set the `transport` option to nodeHttpRequest");
 }
 
 export function WebsocketTransportFactory(transportOptions: TransportOptions): Transport | Error {


### PR DESCRIPTION
This is an alternative to https://github.com/improbable-eng/grpc-web/pull/203/files, and arguably a better solution.  The downside is that this is a breaking change for any Node users, which means merging this will require a major version increment.  This change simply requires that the developer import the Node transport if they want it, instead of automatically detecting it.  This ensures the Node transport can be omitted with static analysis.