### PR TITLE
grpcClient.finishSend() is essential for websocket transport

### DIFF
--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -154,12 +154,8 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 	req.Body = wrappedReader
 	req.Method = http.MethodPost
 	req.Header = headers
-	req.ProtoMajor = 2
-	req.ProtoMinor = 0
-	contentType := req.Header.Get("content-type")
-	req.Header.Set("content-type", strings.Replace(contentType, "application/grpc-web", "application/grpc", 1))
 
-	w.server.ServeHTTP(respWriter, req)
+	w.server.ServeHTTP(respWriter, hackIntoNormalGrpcRequest(req))
 }
 
 // IsGrpcWebRequest determines if a request is a gRPC-Web request by checking that the "content-type" is

--- a/ts/src/invoke.ts
+++ b/ts/src/invoke.ts
@@ -45,6 +45,7 @@ export function invoke<TRequest extends ProtobufMessage, TResponse extends Proto
 
   grpcClient.start(props.metadata);
   grpcClient.send(props.request);
+  grpcClient.finishSend();
 
   return {
     close: () => {

--- a/ts/src/unary.ts
+++ b/ts/src/unary.ts
@@ -57,6 +57,7 @@ export function unary<TRequest extends ProtobufMessage, TResponse extends Protob
 
   grpcClient.start(props.metadata);
   grpcClient.send(props.request);
+  grpcClient.finishSend();
 
   return {
     close: () => {


### PR DESCRIPTION
this PR is based on the found bug report: https://github.com/improbable-eng/grpc-web/pull/180#issuecomment-397564156
