### PR TITLE
Proxy: Correct Content-Type in response

### DIFF
--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -90,6 +90,7 @@ func (w *grpcWebResponse) copyTrailersAndHeadersToWrapped() {
 		}
 	}
 	w.writeCorsExposedHeaders()
+	hackIntogRPCWebContentType(wrappedHeader)
 	w.wrapped.WriteHeader(http.StatusOK)
 	w.wrapped.(http.Flusher).Flush()
 }
@@ -134,5 +135,16 @@ func (w *grpcWebResponse) extractTrailerHeaders() trailer {
 			trailerHeaders.Add(k, v)
 		}
 	}
+	hackIntogRPCWebContentType(trailerHeaders)
 	return trailerHeaders
+}
+
+type headerLike interface {
+	Get(string) string
+	Set(string, string)
+}
+
+func hackIntogRPCWebContentType(in headerLike) {
+	contentType := in.Get("content-type")
+	in.Set("content-type", strings.Replace(contentType, "application/grpc", "application/grpc-web", 1))
 }

--- a/go/grpcweb/trailer.go
+++ b/go/grpcweb/trailer.go
@@ -24,9 +24,15 @@ func (t trailer) Get(key string) string {
 	if t.Header == nil {
 		return ""
 	}
+	key = strings.ToLower(key)
 	v := t.Header[key]
 	if len(v) == 0 {
 		return ""
 	}
 	return v[0]
+}
+
+func (t trailer) Set(key, value string) {
+	key = strings.ToLower(key)
+	t.Header[key] = []string{value}
 }


### PR DESCRIPTION
The Content-Type header in the request is automatically changed from application/grpc-web to application/grpc, however, no corresponding conversion is done for response headers and trailers. This commit adds this functionality, both to early headers and to the in-body trailers.

Found while writing my own WASM gRPC-Web client in Go (in a fork of grpc/grpc-go).