### PR TITLE
Document grpc-web-proxy build requirements

### DIFF
--- a/go/grpcwebproxy/README.md
+++ b/go/grpcwebproxy/README.md
@@ -17,17 +17,20 @@ The indented use is as a companion process for gRPC server containers.
 
 ## Installing
 
-To install, you need to have Go >= 1.8, and call `go get`:
+To install, you need to have Go >= 1.8, and call `go get` with `dep ensure`:
 
-```
+```sh
 go get -u github.com/improbable-eng/grpc-web/go/grpcwebproxy
+cd $GOPATH/src/github.com/improbable-eng/grpc-web/go/grpcwebproxy
+dep ensure # make sure you have golang/dep installed
+go get -u github.com/improbable-eng/grpc-web/go/grpcwebproxy # one more time
 ```
 
 ## Running
 
 Here's a simple example that fronts a local, TLS gRPC server:
 
-```
+```sh
 $GOPATH/bin/grpcwebproxy
     --server_tls_cert_file=../../misc/localhost.crt \
     --server_tls_key_file=../../misc/localhost.key \
@@ -41,7 +44,7 @@ By default, grpcwebproxy will run both TLS and HTTP debug servers. To disable ei
 
 For example, to only run the HTTP server, run the following:
 
-```
+```sh
 $GOPATH/bin/grpcwebproxy
     --backend_addr=localhost:9090 \
     --run_tls_server=false

--- a/go/grpcwebproxy/README.md
+++ b/go/grpcwebproxy/README.md
@@ -17,13 +17,20 @@ The indented use is as a companion process for gRPC server containers.
 
 ## Installing
 
-To install, you need to have Go >= 1.8, and call `go get` with `dep ensure`:
+### Pre-build binaries
+
+There are pre-build binaries available for Windows, Mac and Linux (x86_64):
+https://github.com/improbable-eng/grpc-web/releases/tag/0.6.3
+
+### Building from source
+
+To build, you need to have Go >= 1.8, and call `go get` with `dep ensure`:
 
 ```sh
-go get -u github.com/improbable-eng/grpc-web/go/grpcwebproxy
-cd $GOPATH/src/github.com/improbable-eng/grpc-web/go/grpcwebproxy
-dep ensure # make sure you have golang/dep installed
-go get -u github.com/improbable-eng/grpc-web/go/grpcwebproxy # one more time
+git clone github.com/improbable-eng/grpc-web $GOPATH/src/
+cd $GOPATH/src/github.com/improbable-eng/grpc-web
+dep ensure # after installing dep
+go install ./go/grpcwebproxy # installs into $GOPATH/bin/grpcwebproxy
 ```
 
 ## Running
@@ -31,7 +38,7 @@ go get -u github.com/improbable-eng/grpc-web/go/grpcwebproxy # one more time
 Here's a simple example that fronts a local, TLS gRPC server:
 
 ```sh
-$GOPATH/bin/grpcwebproxy
+grpcwebproxy
     --server_tls_cert_file=../../misc/localhost.crt \
     --server_tls_key_file=../../misc/localhost.key \
     --backend_addr=localhost:9090 \
@@ -45,7 +52,7 @@ By default, grpcwebproxy will run both TLS and HTTP debug servers. To disable ei
 For example, to only run the HTTP server, run the following:
 
 ```sh
-$GOPATH/bin/grpcwebproxy
+grpcwebproxy
     --backend_addr=localhost:9090 \
     --run_tls_server=false
 ```


### PR DESCRIPTION
I'm new to Go, and it took me almost 2 hours to figure out how to get `grpcwebproxy` to exist in the `bin` folder, because I had no idea to run `dep ensure` (or what it even was).

This will save the next newb some time.

Fixes #152 