### PR TITLE
Fixes headers/trailers being lost when grpc-status is non-zero. 

### DIFF
--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -100,7 +100,7 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
       const gRPCStatus: Code = parseInt(headers.get("grpc-status")[0], 10);
       this.props.debug && debug("onHeaders.gRPCStatus", gRPCStatus);
 
-      const code: Code = gRPCStatus >= 0 ? gRPCStatus : httpStatusToCode(status);
+      const code = gRPCStatus >= 0 ? gRPCStatus : httpStatusToCode(status);
       this.props.debug && debug("onHeaders.code", code);
 
       const gRPCMessage = headers.get("grpc-message") || [];

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -97,10 +97,10 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
       this.responseHeaders = headers;
       this.props.debug && debug("onHeaders.responseHeaders", JSON.stringify(this.responseHeaders, null, 2));
 
-      const gRPCStatus: Code = parseInt(headers.get("grpc-status")[0], 10);
+      const gRPCStatus = getStatusFromHeaders(headers);
       this.props.debug && debug("onHeaders.gRPCStatus", gRPCStatus);
 
-      const code = gRPCStatus >= 0 ? gRPCStatus : httpStatusToCode(status);
+      const code = gRPCStatus && gRPCStatus >= 0 ? gRPCStatus : httpStatusToCode(status);
       this.props.debug && debug("onHeaders.code", code);
 
       const gRPCMessage = headers.get("grpc-message") || [];


### PR DESCRIPTION
- rawOnHeaders now called even on grpc errors.
- Derived grpc status `code` defaults to grpc-status if available on headers with `httpStatusToCode()` as fallback.
- headers (trailers) now provided to rawOnError (defaults to new Metadata () if none provided).

Closes issue #225 