### PR TITLE
Add option to increase max message size

### DIFF
--- a/go/grpcwebproxy/README.md
+++ b/go/grpcwebproxy/README.md
@@ -66,3 +66,17 @@ $GOPATH/bin/grpcwebproxy \
     --backend_addr=localhost:9090 \
     --use_websockets
 ```
+
+### Changing the Maximum Receive Message Size
+
+By default, grpcwebproxy will limit the message size that the backend sends to the client. This is currently 4MB.
+To override this, set the `--backend_max_call_recv_msg_size` flag to an integer with the desired byte size.
+
+For example, to increase the size to 5MB, set the value to 5242880 (5 * 1024 * 1024).
+
+```bash
+grpcwebproxy \
+    --backend_max_call_recv_msg_size=5242880
+```
+
+Note that if you set a lower value than 4MB, the lower value will be used. Also, it is preferrable to send data in a stream than to set a very large value.

--- a/go/grpcwebproxy/backend.go
+++ b/go/grpcwebproxy/backend.go
@@ -54,7 +54,7 @@ func dialBackendOrFail() *grpc.ClientConn {
 	} else {
 		opt = append(opt, grpc.WithInsecure())
 	}
-	opt = append(opt, grpc.MaxCallRecvMsgSize(*flagMaxCallRecvMsgSize))
+	opt = append(opt, grpc.WithDefaultCallOptions(MaxCallRecvMsgSize(*flagMaxCallRecvMsgSize)))
 	cc, err := grpc.Dial(*flagBackendHostPort, opt...)
 	if err != nil {
 		logrus.Fatalf("failed dialing backend: %v", err)

--- a/go/grpcwebproxy/backend.go
+++ b/go/grpcwebproxy/backend.go
@@ -54,7 +54,7 @@ func dialBackendOrFail() *grpc.ClientConn {
 	} else {
 		opt = append(opt, grpc.WithInsecure())
 	}
-	opt = append(opt, grpc.WithDefaultCallOptions(MaxCallRecvMsgSize(*flagMaxCallRecvMsgSize)))
+	opt = append(opt, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*flagMaxCallRecvMsgSize)))
 	cc, err := grpc.Dial(*flagBackendHostPort, opt...)
 	if err != nil {
 		logrus.Fatalf("failed dialing backend: %v", err)

--- a/go/grpcwebproxy/backend.go
+++ b/go/grpcwebproxy/backend.go
@@ -55,7 +55,7 @@ func dialBackendOrFail() *grpc.ClientConn {
 		opt = append(opt, grpc.WithInsecure())
 	}
 	if *flagMaxMsgSize != 4194304 {
-		opt = append(opt, grpc.WithMaxMsgSize())
+		opt = append(opt, grpc.WithMaxMsgSize(flagMaxMsgSize))
 	}
 	cc, err := grpc.Dial(*flagBackendHostPort, opt...)
 	if err != nil {

--- a/go/grpcwebproxy/backend.go
+++ b/go/grpcwebproxy/backend.go
@@ -30,6 +30,12 @@ var (
 		"Whether to ignore TLS verification checks (cert validity, hostname). *DO NOT USE IN PRODUCTION*.",
 	)
 
+	flagMaxMsgSize = pflag.Int(
+		"backend_max_msg_size",
+		4194304,
+		"Maximum message size limit. If not specified, the default of 4MB will be used.",
+	)
+
 	flagBackendTlsCa = pflag.StringSlice(
 		"backend_tls_ca_files",
 		[]string{},
@@ -47,6 +53,9 @@ func dialBackendOrFail() *grpc.ClientConn {
 		opt = append(opt, grpc.WithTransportCredentials(credentials.NewTLS(buildBackendTlsOrFail())))
 	} else {
 		opt = append(opt, grpc.WithInsecure())
+	}
+	if *flagMaxMsgSize != 4194304 {
+		opt = append(opt, grpc.WithMaxMsgSize())
 	}
 	cc, err := grpc.Dial(*flagBackendHostPort, opt...)
 	if err != nil {

--- a/go/grpcwebproxy/backend.go
+++ b/go/grpcwebproxy/backend.go
@@ -30,10 +30,10 @@ var (
 		"Whether to ignore TLS verification checks (cert validity, hostname). *DO NOT USE IN PRODUCTION*.",
 	)
 
-	flagMaxMsgSize = pflag.Int(
-		"backend_max_msg_size",
-		4194304,
-		"Maximum message size limit. If not specified, the default of 4MB will be used.",
+	flagMaxCallRecvMsgSize = pflag.Int(
+		"backend_max_call_recv_msg_size",
+		1024*1024*4, // The current maximum receive msg size per https://github.com/grpc/grpc-go/blob/v1.8.2/server.go#L54
+		"Maximum receive message size limit. If not specified, the default of 4MB will be used.",
 	)
 
 	flagBackendTlsCa = pflag.StringSlice(
@@ -54,9 +54,7 @@ func dialBackendOrFail() *grpc.ClientConn {
 	} else {
 		opt = append(opt, grpc.WithInsecure())
 	}
-	if *flagMaxMsgSize != 4194304 {
-		opt = append(opt, grpc.WithMaxMsgSize(flagMaxMsgSize))
-	}
+	opt = append(opt, grpc.MaxCallRecvMsgSize(*flagMaxCallRecvMsgSize))
 	cc, err := grpc.Dial(*flagBackendHostPort, opt...)
 	if err != nil {
 		logrus.Fatalf("failed dialing backend: %v", err)


### PR DESCRIPTION
Adds the option to pass an integer value as the `grpc.WithMaxMsgSize` from https://godoc.org/google.golang.org/grpc#WithMaxMsgSize, https://github.com/grpc/grpc-go/blob/master/dialoptions.go#L147.

ref #245 