### PR TITLE
Prevent leaking goroutines from websocket connections

### DIFF
--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"context"
 	"strings"
 	"time"
 
@@ -148,14 +149,17 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 		return
 	}
 
+	ctx, cancelFunc := context.WithCancel(req.Context())
+	defer cancelFunc()
+
 	respWriter := newWebSocketResponseWriter(wsConn)
-	wrappedReader := newWebsocketWrappedReader(wsConn, respWriter)
+	wrappedReader := newWebsocketWrappedReader(wsConn, respWriter, cancelFunc)
 
 	req.Body = wrappedReader
 	req.Method = http.MethodPost
 	req.Header = headers
 
-	w.server.ServeHTTP(respWriter, hackIntoNormalGrpcRequest(req))
+	w.server.ServeHTTP(respWriter, hackIntoNormalGrpcRequest(req.WithContext(ctx)))
 }
 
 // IsGrpcWebRequest determines if a request is a gRPC-Web request by checking that the "content-type" is


### PR DESCRIPTION
The write to the CloseNotify() channel was blocking, preventing the
Read() call from exiting, and preventing ServeHTTP from returning. This
meant that requests tended to stay around forever in a deadlocked state.

Using the context package prevent this, as the cancellation is
non-blocking. It depends on Go 1.7.

Note that the writer still needs to support the CloseNotifier interface,
otherwise other things break, but it does not seem to be necessary to
signal using it.