### PR TITLE
client: don't call callbacks if close() is called

### DIFF
--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -209,6 +209,7 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
 
     this.onEndCallbacks.forEach(callback => {
       detach(() => {
+        if (this.closed) return;
         callback(code, message, trailers);
       });
     });
@@ -230,6 +231,7 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
     this.completed = true;
     this.onEndCallbacks.forEach(callback => {
       detach(() => {
+        if (this.closed) return;
         callback(code, msg, trailers);
       });
     });
@@ -240,6 +242,7 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
     if (this.completed || this.closed) return;
     this.onMessageCallbacks.forEach(callback => {
       detach(() => {
+        if (this.closed) return;
         callback(res);
       });
     });


### PR DESCRIPTION
- This could break some existing clients using the raw grpc API (maybe should document it?), but ts-protoc-gen clears out the callbacks anyways so this shouldn't cause anyone pain
- Fixes #257

... I'd write a test for this, but I'm not actually a Javascript/Typescript developer so I'm not familiar with the test framework.