### PR TITLE
Remove Chrome 42 from CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - BROWSER=chrome_57
     - BROWSER=chrome_52
     - BROWSER=chrome_43
-    - BROWSER=chrome_42
     - BROWSER=chrome_41
     # Edge does not support aborting fetch requests (documented known limitation in project README)
     - BROWSER=edge15_win DISABLE_ABORT_TESTS=true


### PR DESCRIPTION
As mentioned in #259, this seems to just be failing on setup now, we should remove it so as not to block community contributions.

Fixes #259