### PR TITLE
Add support for specifying a default :authority header for backend calls

### DIFF
--- a/go/grpcwebproxy/backend.go
+++ b/go/grpcwebproxy/backend.go
@@ -41,6 +41,12 @@ var (
 		[]string{},
 		"Paths (comma separated) to PEM certificate chains used for verification of backend certificates. If empty, host CA chain will be used.",
 	)
+
+	flagBackendDefaultAuthority = pflag.String(
+		"backend_default_authority",
+		"",
+		"Default value to use for the HTTP/2 :authority header commonly used for routing gRPC calls through a backend gateway.",
+	)
 )
 
 func dialBackendOrFail() *grpc.ClientConn {
@@ -49,6 +55,11 @@ func dialBackendOrFail() *grpc.ClientConn {
 	}
 	opt := []grpc.DialOption{}
 	opt = append(opt, grpc.WithCodec(proxy.Codec()))
+
+	if *flagBackendDefaultAuthority != "" {
+		opt = append(opt, grpc.WithAuthority(*flagBackendDefaultAuthority))
+	}
+
 	if *flagBackendIsUsingTls {
 		opt = append(opt, grpc.WithTransportCredentials(credentials.NewTLS(buildBackendTlsOrFail())))
 	} else {

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -30,7 +30,7 @@ var (
 	flagBindAddr    = pflag.String("server_bind_address", "0.0.0.0", "address to bind the server to")
 	flagHttpPort    = pflag.Int("server_http_debug_port", 8080, "TCP port to listen on for HTTP1.1 debug calls.")
 	flagHttpTlsPort = pflag.Int("server_http_tls_port", 8443, "TCP port to listen on for HTTPS (gRPC, gRPC-Web).")
-
+	
 	runHttpServer = pflag.Bool("run_http_server", true, "whether to run HTTP server")
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
 


### PR DESCRIPTION
It is called "default" largely because that is what gRPC core calls it ("grpc.default_authority"). It could later be overridden on a per-call basis once gRPC-Web protocol defines proper handling of this header.

This is a workaround (not a true fix) for #266. A real fix would take this value from the client on a per-call basis.