### PR TITLE
Define and Export RpcOptions interface

### DIFF
--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -8,10 +8,13 @@ import {MethodDefinition} from "./service";
 import {frameRequest} from "./util";
 import {ProtobufMessage} from "./message";
 
-export interface ClientRpcOptions {
-  host: string;
+export interface RpcOptions {
   transport?: TransportFactory;
   debug?: boolean;
+}
+
+export interface ClientRpcOptions extends RpcOptions {
+  host: string;
 }
 
 export interface Client<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -42,6 +42,7 @@ export namespace grpc {
   export function client<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends MethodDefinition<TRequest, TResponse>>(methodDescriptor: M, props: ClientRpcOptions): Client<TRequest, TResponse> {
     return impClient.client(methodDescriptor, props);
   }
+  export interface RpcOptions extends impClient.RpcOptions {}
   export interface ClientRpcOptions extends impClient.ClientRpcOptions {}
 
   export const invoke = impInvoke.invoke;

--- a/ts/src/invoke.ts
+++ b/ts/src/invoke.ts
@@ -1,8 +1,7 @@
 import {Code} from "./Code";
-import {TransportFactory} from "./transports/Transport";
 import {MethodDefinition} from "./service";
 import {Metadata} from "./metadata";
-import {client} from "./client";
+import {client, RpcOptions} from "./client";
 import {ProtobufMessage} from "./message";
 
 export interface Request {

--- a/ts/src/invoke.ts
+++ b/ts/src/invoke.ts
@@ -9,15 +9,13 @@ export interface Request {
   close: () => void;
 }
 
-export interface InvokeRpcOptions<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> {
+export interface InvokeRpcOptions<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> extends RpcOptions {
   host: string;
   request: TRequest;
   metadata?: Metadata.ConstructorArg;
   onHeaders?: (headers: Metadata) => void;
   onMessage?: (res: TResponse) => void;
   onEnd: (code: Code, message: string, trailers: Metadata) => void;
-  transport?: TransportFactory;
-  debug?: boolean;
 }
 
 

--- a/ts/src/unary.ts
+++ b/ts/src/unary.ts
@@ -14,13 +14,11 @@ export interface UnaryOutput<TResponse> {
   trailers: Metadata;
 }
 
-export interface UnaryRpcOptions<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> {
+export interface UnaryRpcOptions<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> extends RpcOptions {
   host: string;
   request: TRequest;
   metadata?: Metadata.ConstructorArg;
   onEnd: (output: UnaryOutput<TResponse>) => void;
-  transport?: TransportFactory;
-  debug?: boolean;
 }
 
 export function unary<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends UnaryMethodDefinition<TRequest, TResponse>>(methodDescriptor: M, props: UnaryRpcOptions<TRequest, TResponse>): Request {

--- a/ts/src/unary.ts
+++ b/ts/src/unary.ts
@@ -1,9 +1,8 @@
 import {Metadata} from "./metadata";
 import {Code} from "./Code";
 import {UnaryMethodDefinition} from "./service";
-import {TransportFactory} from "./transports/Transport";
 import {Request} from "./invoke";
-import {client} from "./client";
+import {client, RpcOptions} from "./client";
 import {ProtobufMessage} from "./message";
 
 export interface UnaryOutput<TResponse> {


### PR DESCRIPTION
This allows us to import it in ts-protoc-gen and avoid us having to duplicate the definition.

Note the motivation for making this change is that I've just realised that 0.7.0 will break ts-protoc-gen as it expects the `transport` property to be typed as a `TransportConstructor`, not a `TransportFactory`.