### PR TITLE
Fix gRPC Web spec violation related to header/trailer names

### DIFF
--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -114,9 +114,9 @@ func (w *grpcWebResponse) copyTrailersToPayload() {
 	w.wrapped.(http.Flusher).Flush()
 }
 
-func (w *grpcWebResponse) extractTrailerHeaders() header {
+func (w *grpcWebResponse) extractTrailerHeaders() trailer {
 	flushedHeaders := w.wrapped.Header()
-	trailerHeaders := header{make(http.Header)}
+	trailerHeaders := trailer{make(http.Header)}
 	for k, vv := range w.headers {
 		// Skip the pre-annoucement of Trailer headers. Don't add them to the response headers.
 		if strings.ToLower(k) == "trailer" {

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -146,14 +146,8 @@ func (w *grpcWebResponse) mapHeaderKeysToLower() {
 	mapped := make(header)
 	for k, vv := range w.headers {
 		lowerKey := strings.ToLower(k)
-		// Use append directly instead of mapped.Add because mapped.Add calls strings.ToLower(k)
 		for _, v := range vv {
-			// If trailer headers, map to lower these keys.
-			if lowerKey == "trailer" {
-				mapped[lowerKey] = append(mapped[lowerKey], strings.ToLower(v))
-			} else {
-				mapped[lowerKey] = append(mapped[lowerKey], v)
-			}
+			mapped.Add(k, v)
 		}
 	}
 	w.headers = mapped.toHTTPHeader()

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -66,7 +66,10 @@ func (w *grpcWebResponse) copyJustHeadersToWrapped() {
 }
 
 func (w *grpcWebResponse) finishRequest(req *http.Request) {
-	w.mapHeaderKeysToLower()
+	// HTTP/2 always uses lower header/trailer keys.
+	if req.ProtoMajor == 1 {
+		w.mapHeaderKeysToLower()
+	}
 	if w.wroteHeaders || w.wroteBody {
 		w.copyTrailersToPayload()
 	} else {

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -77,9 +77,8 @@ func (w *grpcWebResponse) copyTrailersAndHeadersToWrapped() {
 	w.wroteHeaders = true
 	wrappedHeader := w.wrapped.Header()
 	for k, vv := range w.headers {
-		lowerKey := strings.ToLower(k)
 		// Skip the pre-annoucement of Trailer headers. Don't add them to the response headers.
-		if lowerKey == "trailer" {
+		if strings.ToLower(k) == "trailer" {
 			continue
 		}
 		// Skip the Trailer prefix
@@ -87,7 +86,7 @@ func (w *grpcWebResponse) copyTrailersAndHeadersToWrapped() {
 			k = k[len(http2.TrailerPrefix):]
 		}
 		for _, v := range vv {
-			wrappedHeader.Add(lowerKey, v)
+			wrappedHeader.Add(k, v)
 		}
 	}
 	w.writeCorsExposedHeaders()

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -77,8 +77,9 @@ func (w *grpcWebResponse) copyTrailersAndHeadersToWrapped() {
 	w.wroteHeaders = true
 	wrappedHeader := w.wrapped.Header()
 	for k, vv := range w.headers {
+		lowerKey := strings.ToLower(k)
 		// Skip the pre-annoucement of Trailer headers. Don't add them to the response headers.
-		if strings.ToLower(k) == "trailer" {
+		if lowerKey == "trailer" {
 			continue
 		}
 		// Skip the Trailer prefix
@@ -86,7 +87,7 @@ func (w *grpcWebResponse) copyTrailersAndHeadersToWrapped() {
 			k = k[len(http2.TrailerPrefix):]
 		}
 		for _, v := range vv {
-			wrappedHeader.Add(k, v)
+			wrappedHeader.Add(lowerKey, v)
 		}
 	}
 	w.writeCorsExposedHeaders()

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -66,7 +66,8 @@ func (w *grpcWebResponse) copyJustHeadersToWrapped() {
 }
 
 func (w *grpcWebResponse) finishRequest(req *http.Request) {
-	// HTTP/2 always uses lower header/trailer keys.
+	// We must use lower-case header/trailer names.
+	// See "HTTP wire protocols" section in https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
 	if req.ProtoMajor == 1 {
 		w.mapHeaderKeysToLower()
 	}

--- a/go/grpcweb/header.go
+++ b/go/grpcweb/header.go
@@ -1,10 +1,16 @@
 package grpcweb
 
 import (
+	"io"
 	"net/http"
+	"net/http/httptrace"
+	"net/textproto"
+	"sort"
 	"strings"
+	"sync"
 )
 
+// Almost of header's methods are copied from http.Header.
 type header struct {
 	http.Header
 }
@@ -21,4 +27,107 @@ func (h header) Add(key, value string) {
 
 func (h header) toHTTPHeader() http.Header {
 	return h.Header
+}
+
+// Write writes a header in wire format.
+func (h header) Write(w io.Writer) error {
+	return h.write(w, nil)
+}
+
+func (h header) write(w io.Writer, trace *httptrace.ClientTrace) error {
+	return h.writeSubset(w, nil, trace)
+}
+
+func (h header) clone() header {
+	h2 := header{make(http.Header, len(h.Header))}
+	for k, vv := range h.Header {
+		vv2 := make([]string, len(vv))
+		copy(vv2, vv)
+		h2.Header[k] = vv2
+	}
+	return h2
+}
+
+var headerNewlineToSpace = strings.NewReplacer("\n", " ", "\r", " ")
+
+type writeStringer interface {
+	WriteString(string) (int, error)
+}
+
+// stringWriter implements WriteString on a Writer.
+type stringWriter struct {
+	w io.Writer
+}
+
+func (w stringWriter) WriteString(s string) (n int, err error) {
+	return w.w.Write([]byte(s))
+}
+
+type keyValues struct {
+	key    string
+	values []string
+}
+
+// A headerSorter implements sort.Interface by sorting a []keyValues
+// by key. It's used as a pointer, so it can fit in a sort.Interface
+// interface value without allocation.
+type headerSorter struct {
+	kvs []keyValues
+}
+
+func (s *headerSorter) Len() int           { return len(s.kvs) }
+func (s *headerSorter) Swap(i, j int)      { s.kvs[i], s.kvs[j] = s.kvs[j], s.kvs[i] }
+func (s *headerSorter) Less(i, j int) bool { return s.kvs[i].key < s.kvs[j].key }
+
+var headerSorterPool = sync.Pool{
+	New: func() interface{} { return new(headerSorter) },
+}
+
+// sortedKeyValues returns h's keys sorted in the returned kvs
+// slice. The headerSorter used to sort is also returned, for possible
+// return to headerSorterCache.
+func (h header) sortedKeyValues(exclude map[string]bool) (kvs []keyValues, hs *headerSorter) {
+	hs = headerSorterPool.Get().(*headerSorter)
+	if cap(hs.kvs) < len(h.Header) {
+		hs.kvs = make([]keyValues, 0, len(h.Header))
+	}
+	kvs = hs.kvs[:0]
+	for k, vv := range h.Header {
+		if !exclude[k] {
+			kvs = append(kvs, keyValues{k, vv})
+		}
+	}
+	hs.kvs = kvs
+	sort.Sort(hs)
+	return kvs, hs
+}
+
+func (h header) writeSubset(w io.Writer, exclude map[string]bool, trace *httptrace.ClientTrace) error {
+	ws, ok := w.(writeStringer)
+	if !ok {
+		ws = stringWriter{w}
+	}
+	kvs, sorter := h.sortedKeyValues(exclude)
+	var formattedVals []string
+	for _, kv := range kvs {
+		for _, v := range kv.values {
+			v = headerNewlineToSpace.Replace(v)
+			v = textproto.TrimString(v)
+			for _, s := range []string{strings.ToLower(kv.key), ": ", v, "\r\n"} {
+				if _, err := ws.WriteString(s); err != nil {
+					headerSorterPool.Put(sorter)
+					return err
+				}
+			}
+			if trace != nil && trace.WroteHeaderField != nil {
+				formattedVals = append(formattedVals, v)
+			}
+		}
+		if trace != nil && trace.WroteHeaderField != nil {
+			trace.WroteHeaderField(kv.key, formattedVals)
+			formattedVals = nil
+		}
+	}
+	headerSorterPool.Put(sorter)
+	return nil
 }

--- a/go/grpcweb/header.go
+++ b/go/grpcweb/header.go
@@ -1,0 +1,17 @@
+package grpcweb
+
+import (
+	"net/http"
+	"strings"
+)
+
+type header map[string][]string
+
+func (h header) Add(key, value string) {
+	lowerKey := strings.ToLower(key)
+	h[lowerKey] = append(h[lowerKey], value)
+}
+
+func (h header) toHTTPHeader() http.Header {
+	return http.Header(h)
+}

--- a/go/grpcweb/header.go
+++ b/go/grpcweb/header.go
@@ -11,6 +11,11 @@ type header struct {
 
 func (h header) Add(key, value string) {
 	lowerKey := strings.ToLower(key)
+
+	// If trailer headers, map to lower these keys.
+	if lowerKey == "trailer" {
+		value = strings.ToLower(value)
+	}
 	h.Header[lowerKey] = append(h.Header[lowerKey], value)
 }
 

--- a/go/grpcweb/header.go
+++ b/go/grpcweb/header.go
@@ -5,13 +5,15 @@ import (
 	"strings"
 )
 
-type header map[string][]string
+type header struct {
+	http.Header
+}
 
 func (h header) Add(key, value string) {
 	lowerKey := strings.ToLower(key)
-	h[lowerKey] = append(h[lowerKey], value)
+	h.Header[lowerKey] = append(h.Header[lowerKey], value)
 }
 
 func (h header) toHTTPHeader() http.Header {
-	return http.Header(h)
+	return h.Header
 }

--- a/go/grpcweb/trailer.go
+++ b/go/grpcweb/trailer.go
@@ -19,3 +19,14 @@ func (t trailer) Add(key, value string) {
 	key = strings.ToLower(key)
 	t.Header[key] = append(t.Header[key], value)
 }
+
+func (t trailer) Get(key string) string {
+	if t.Header == nil {
+		return ""
+	}
+	v := t.Header[key]
+	if len(v) == 0 {
+		return ""
+	}
+	return v[0]
+}

--- a/go/grpcweb/trailer.go
+++ b/go/grpcweb/trailer.go
@@ -4,12 +4,8 @@
 package grpcweb
 
 import (
-	"io"
 	"net/http"
-	"net/textproto"
-	"sort"
 	"strings"
-	"sync"
 )
 
 // gRPC-Web spec says that must use lower-case header/trailer names.
@@ -27,73 +23,4 @@ func (t trailer) Add(key, value string) {
 		value = strings.ToLower(value)
 	}
 	t.Header[lowerKey] = append(t.Header[lowerKey], value)
-}
-
-// Write writes a header in wire format.
-func (t trailer) Write(w io.Writer) error {
-	ws, ok := w.(writeStringer)
-	if !ok {
-		ws = stringWriter{w}
-	}
-
-	sorter := headerSorterPool.Get().(*headerSorter)
-	if cap(sorter.kvs) < len(t.Header) {
-		sorter.kvs = make([]keyValues, 0, len(t.Header))
-	}
-	kvs := sorter.kvs[:0]
-	for k, vv := range t.Header {
-		kvs = append(kvs, keyValues{k, vv})
-	}
-	sorter.kvs = kvs
-	sort.Sort(sorter)
-
-	for _, kv := range kvs {
-		for _, v := range kv.values {
-			v = headerNewlineToSpace.Replace(v)
-			v = textproto.TrimString(v)
-			for _, s := range []string{strings.ToLower(kv.key), ": ", v, "\r\n"} {
-				if _, err := ws.WriteString(s); err != nil {
-					headerSorterPool.Put(sorter)
-					return err
-				}
-			}
-		}
-	}
-	headerSorterPool.Put(sorter)
-	return nil
-}
-
-var headerNewlineToSpace = strings.NewReplacer("\n", " ", "\r", " ")
-
-type writeStringer interface {
-	WriteString(string) (int, error)
-}
-
-// stringWriter implements WriteString on a Writer.
-type stringWriter struct {
-	w io.Writer
-}
-
-func (w stringWriter) WriteString(s string) (n int, err error) {
-	return w.w.Write([]byte(s))
-}
-
-type keyValues struct {
-	key    string
-	values []string
-}
-
-// A headerSorter implements sort.Interface by sorting a []keyValues
-// by key. It's used as a pointer, so it can fit in a sort.Interface
-// interface value without allocation.
-type headerSorter struct {
-	kvs []keyValues
-}
-
-func (s *headerSorter) Len() int           { return len(s.kvs) }
-func (s *headerSorter) Swap(i, j int)      { s.kvs[i], s.kvs[j] = s.kvs[j], s.kvs[i] }
-func (s *headerSorter) Less(i, j int) bool { return s.kvs[i].key < s.kvs[j].key }
-
-var headerSorterPool = sync.Pool{
-	New: func() interface{} { return new(headerSorter) },
 }

--- a/go/grpcweb/trailer.go
+++ b/go/grpcweb/trailer.go
@@ -1,3 +1,6 @@
+//Copyright 2017 Improbable. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package grpcweb
 
 import (
@@ -10,6 +13,10 @@ import (
 	"sync"
 )
 
+// gRPC-Web spec says that must use lower-case header/trailer names.
+// See "HTTP wire protocols" section in
+// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+//
 // Almost of trailer's methods are copied from http.Header.
 type trailer struct {
 	http.Header

--- a/go/grpcweb/trailer.go
+++ b/go/grpcweb/trailer.go
@@ -16,11 +16,6 @@ type trailer struct {
 }
 
 func (t trailer) Add(key, value string) {
-	lowerKey := strings.ToLower(key)
-
-	// If trailer headers, map to lower these keys.
-	if lowerKey == "trailer" {
-		value = strings.ToLower(value)
-	}
-	t.Header[lowerKey] = append(t.Header[lowerKey], value)
+	key = strings.ToLower(key)
+	t.Header[key] = append(t.Header[key], value)
 }

--- a/go/grpcweb/trailer.go
+++ b/go/grpcweb/trailer.go
@@ -1,4 +1,4 @@
-//Copyright 2017 Improbable. All Rights Reserved.
+//Copyright 2018 Improbable. All Rights Reserved.
 // See LICENSE for licensing terms.
 
 package grpcweb

--- a/go/grpcweb/trailer.go
+++ b/go/grpcweb/trailer.go
@@ -6,7 +6,6 @@ package grpcweb
 import (
 	"io"
 	"net/http"
-	"net/http/httptrace"
 	"net/textproto"
 	"sort"
 	"strings"
@@ -16,8 +15,6 @@ import (
 // gRPC-Web spec says that must use lower-case header/trailer names.
 // See "HTTP wire protocols" section in
 // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
-//
-// Almost of trailer's methods are copied from http.Header.
 type trailer struct {
 	http.Header
 }
@@ -34,21 +31,36 @@ func (t trailer) Add(key, value string) {
 
 // Write writes a header in wire format.
 func (t trailer) Write(w io.Writer) error {
-	return t.write(w, nil)
-}
-
-func (t trailer) write(w io.Writer, trace *httptrace.ClientTrace) error {
-	return t.writeSubset(w, nil, trace)
-}
-
-func (t trailer) clone() trailer {
-	h2 := trailer{make(http.Header, len(t.Header))}
-	for k, vv := range t.Header {
-		vv2 := make([]string, len(vv))
-		copy(vv2, vv)
-		h2.Header[k] = vv2
+	ws, ok := w.(writeStringer)
+	if !ok {
+		ws = stringWriter{w}
 	}
-	return h2
+
+	sorter := headerSorterPool.Get().(*headerSorter)
+	if cap(sorter.kvs) < len(t.Header) {
+		sorter.kvs = make([]keyValues, 0, len(t.Header))
+	}
+	kvs := sorter.kvs[:0]
+	for k, vv := range t.Header {
+		kvs = append(kvs, keyValues{k, vv})
+	}
+	sorter.kvs = kvs
+	sort.Sort(sorter)
+
+	for _, kv := range kvs {
+		for _, v := range kv.values {
+			v = headerNewlineToSpace.Replace(v)
+			v = textproto.TrimString(v)
+			for _, s := range []string{strings.ToLower(kv.key), ": ", v, "\r\n"} {
+				if _, err := ws.WriteString(s); err != nil {
+					headerSorterPool.Put(sorter)
+					return err
+				}
+			}
+		}
+	}
+	headerSorterPool.Put(sorter)
+	return nil
 }
 
 var headerNewlineToSpace = strings.NewReplacer("\n", " ", "\r", " ")
@@ -84,53 +96,4 @@ func (s *headerSorter) Less(i, j int) bool { return s.kvs[i].key < s.kvs[j].key 
 
 var headerSorterPool = sync.Pool{
 	New: func() interface{} { return new(headerSorter) },
-}
-
-// sortedKeyValues returns h's keys sorted in the returned kvs
-// slice. The headerSorter used to sort is also returned, for possible
-// return to headerSorterCache.
-func (t trailer) sortedKeyValues(exclude map[string]bool) (kvs []keyValues, hs *headerSorter) {
-	hs = headerSorterPool.Get().(*headerSorter)
-	if cap(hs.kvs) < len(t.Header) {
-		hs.kvs = make([]keyValues, 0, len(t.Header))
-	}
-	kvs = hs.kvs[:0]
-	for k, vv := range t.Header {
-		if !exclude[k] {
-			kvs = append(kvs, keyValues{k, vv})
-		}
-	}
-	hs.kvs = kvs
-	sort.Sort(hs)
-	return kvs, hs
-}
-
-func (t trailer) writeSubset(w io.Writer, exclude map[string]bool, trace *httptrace.ClientTrace) error {
-	ws, ok := w.(writeStringer)
-	if !ok {
-		ws = stringWriter{w}
-	}
-	kvs, sorter := t.sortedKeyValues(exclude)
-	var formattedVals []string
-	for _, kv := range kvs {
-		for _, v := range kv.values {
-			v = headerNewlineToSpace.Replace(v)
-			v = textproto.TrimString(v)
-			for _, s := range []string{strings.ToLower(kv.key), ": ", v, "\r\n"} {
-				if _, err := ws.WriteString(s); err != nil {
-					headerSorterPool.Put(sorter)
-					return err
-				}
-			}
-			if trace != nil && trace.WroteHeaderField != nil {
-				formattedVals = append(formattedVals, v)
-			}
-		}
-		if trace != nil && trace.WroteHeaderField != nil {
-			trace.WroteHeaderField(kv.key, formattedVals)
-			formattedVals = nil
-		}
-	}
-	headerSorterPool.Put(sorter)
-	return nil
 }

--- a/go/grpcweb/trailer_test.go
+++ b/go/grpcweb/trailer_test.go
@@ -1,0 +1,11 @@
+package grpcweb
+
+import "net/http"
+
+type Trailer struct {
+	trailer
+}
+
+func HTTPTrailerToGrpcWebTrailer(httpTrailer http.Header) Trailer {
+	return Trailer{trailer{httpTrailer}}
+}

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -4,10 +4,9 @@
 package grpcweb
 
 import (
+	"context"
 	"net/http"
 	"net/url"
-
-	"context"
 	"strings"
 	"time"
 

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -111,7 +111,7 @@ func (s *GrpcWebWrapperTestSuite) makeRequest(verb string, method string, header
 	return resp, err
 }
 
-func (s *GrpcWebWrapperTestSuite) makeGrpcRequest(method string, reqHeaders http.Header, requestMessages [][]byte) (headers http.Header, trailers http.Header, responseMessages [][]byte, err error) {
+func (s *GrpcWebWrapperTestSuite) makeGrpcRequest(method string, reqHeaders http.Header, requestMessages [][]byte) (headers http.Header, trailers grpcweb.Trailer, responseMessages [][]byte, err error) {
 	writer := new(bytes.Buffer)
 	for _, msgBytes := range requestMessages {
 		grpcPreamble := []byte{0, 0, 0, 0, 0}
@@ -121,15 +121,15 @@ func (s *GrpcWebWrapperTestSuite) makeGrpcRequest(method string, reqHeaders http
 	}
 	resp, err := s.makeRequest("POST", method, reqHeaders, writer)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, grpcweb.Trailer{}, nil, err
 	}
 	defer resp.Body.Close()
 	contents, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, grpcweb.Trailer{}, nil, err
 	}
 	reader := bytes.NewReader(contents)
-	trailers = make(http.Header)
+	httpTrailers := make(http.Header)
 	for {
 		grpcPreamble := []byte{0, 0, 0, 0, 0}
 		readCount, err := reader.Read(grpcPreamble)
@@ -137,22 +137,22 @@ func (s *GrpcWebWrapperTestSuite) makeGrpcRequest(method string, reqHeaders http
 			break
 		}
 		if readCount != 5 || err != nil {
-			return nil, nil, nil, fmt.Errorf("Unexpected end of body in preamble: %v", err)
+			return nil, grpcweb.Trailer{}, nil, fmt.Errorf("Unexpected end of body in preamble: %v", err)
 		}
 		payloadLength := binary.BigEndian.Uint32(grpcPreamble[1:])
 		payloadBytes := make([]byte, payloadLength)
 
 		readCount, err = reader.Read(payloadBytes)
 		if uint32(readCount) != payloadLength || err != nil {
-			return nil, nil, nil, fmt.Errorf("Unexpected end of msg: %v", err)
+			return nil, grpcweb.Trailer{}, nil, fmt.Errorf("Unexpected end of msg: %v", err)
 		}
 		if grpcPreamble[0]&(1<<7) == (1 << 7) { // MSB signifies the trailer parser
-			trailers = readHeadersFromBytes(s.T(), payloadBytes)
+			httpTrailers = readHeadersFromBytes(s.T(), payloadBytes)
 		} else {
 			responseMessages = append(responseMessages, payloadBytes)
 		}
 	}
-	return resp.Header, trailers, responseMessages, nil
+	return resp.Header, grpcweb.HTTPTrailerToGrpcWebTrailer(httpTrailers), responseMessages, nil
 }
 
 func (s *GrpcWebWrapperTestSuite) TestPingEmpty() {
@@ -165,7 +165,7 @@ func (s *GrpcWebWrapperTestSuite) TestPingEmpty() {
 	assert.Equal(s.T(), 1, len(responses), "PingEmpty is an unary response")
 	s.assertTrailerGrpcCode(trailers, codes.OK, "")
 	s.assertHeadersContainMetadata(headers, expectedHeaders)
-	s.assertHeadersContainMetadata(trailers, expectedTrailers)
+	s.assertTrailersContainMetadata(trailers, expectedTrailers)
 }
 
 func (s *GrpcWebWrapperTestSuite) TestPing() {
@@ -178,7 +178,7 @@ func (s *GrpcWebWrapperTestSuite) TestPing() {
 	assert.Equal(s.T(), 1, len(responses), "PingEmpty is an unary response")
 	s.assertTrailerGrpcCode(trailers, codes.OK, "")
 	s.assertHeadersContainMetadata(headers, expectedHeaders)
-	s.assertHeadersContainMetadata(trailers, expectedTrailers)
+	s.assertTrailersContainMetadata(trailers, expectedTrailers)
 	s.assertHeadersContainCorsExpectedHeaders(headers, expectedHeaders)
 }
 
@@ -194,7 +194,7 @@ func (s *GrpcWebWrapperTestSuite) TestPingError_WithTrailersInData() {
 	assert.Equal(s.T(), 0, len(responses), "PingError is an unary response that has no payload")
 	s.assertTrailerGrpcCode(trailers, codes.Unimplemented, "Not implemented PingError")
 	s.assertHeadersContainMetadata(headers, expectedHeaders)
-	s.assertHeadersContainMetadata(trailers, expectedTrailers)
+	s.assertTrailersContainMetadata(trailers, expectedTrailers)
 	s.assertHeadersContainCorsExpectedHeaders(headers, expectedHeaders)
 }
 
@@ -208,7 +208,7 @@ func (s *GrpcWebWrapperTestSuite) TestPingError_WithTrailersInHeaders() {
 	require.NoError(s.T(), err, "No error on making request")
 
 	assert.Equal(s.T(), 0, len(responses), "PingError is an unary response that has no payload")
-	s.assertTrailerGrpcCode(headers, codes.Unimplemented, "Not implemented PingError")
+	s.assertHeadersGrpcCode(headers, codes.Unimplemented, "Not implemented PingError")
 	// s.assertHeadersContainMetadata(headers, expectedHeaders) // TODO(mwitkow): There is a bug in gRPC where headers don't get added if no payload exists.
 	s.assertHeadersContainMetadata(headers, expectedTrailers)
 	s.assertHeadersContainCorsExpectedHeaders(headers, expectedTrailers)
@@ -223,7 +223,7 @@ func (s *GrpcWebWrapperTestSuite) TestPingList() {
 	assert.Equal(s.T(), expectedListResponses, len(responses), "the number of expected proto fields shouold match")
 	s.assertTrailerGrpcCode(trailers, codes.OK, "")
 	s.assertHeadersContainMetadata(headers, expectedHeaders)
-	s.assertHeadersContainMetadata(trailers, expectedTrailers)
+	s.assertTrailersContainMetadata(trailers, expectedTrailers)
 	s.assertHeadersContainCorsExpectedHeaders(headers, expectedHeaders)
 }
 
@@ -311,6 +311,14 @@ func (s *GrpcWebWrapperTestSuite) assertHeadersContainMetadata(headers http.Head
 	}
 }
 
+func (s *GrpcWebWrapperTestSuite) assertTrailersContainMetadata(trailers grpcweb.Trailer, meta metadata.MD) {
+	for k, v := range meta {
+		for _, vv := range v {
+			assert.Equal(s.T(), trailers.Get(k), vv, "Expected there to be %v=%v", k, vv)
+		}
+	}
+}
+
 func (s *GrpcWebWrapperTestSuite) assertHeadersContainCorsExpectedHeaders(headers http.Header, meta metadata.MD) {
 	value := headers.Get("Access-Control-Expose-Headers")
 	assert.NotEmpty(s.T(), value, "cors: access control expose headers should not be empty")
@@ -322,7 +330,15 @@ func (s *GrpcWebWrapperTestSuite) assertHeadersContainCorsExpectedHeaders(header
 	}
 }
 
-func (s *GrpcWebWrapperTestSuite) assertTrailerGrpcCode(trailers http.Header, code codes.Code, desc string) {
+func (s *GrpcWebWrapperTestSuite) assertHeadersGrpcCode(headers http.Header, code codes.Code, desc string) {
+	require.NotEmpty(s.T(), headers.Get("grpc-status"), "grpc-status must not be empty in trailers")
+	statusCode, err := strconv.Atoi(headers.Get("grpc-status"))
+	require.NoError(s.T(), err, "no error parsing grpc-status")
+	assert.EqualValues(s.T(), code, statusCode, "grpc-status must match expected code")
+	assert.EqualValues(s.T(), desc, headers.Get("grpc-message"), "grpc-message is expected to match")
+}
+
+func (s *GrpcWebWrapperTestSuite) assertTrailerGrpcCode(trailers grpcweb.Trailer, code codes.Code, desc string) {
 	require.NotEmpty(s.T(), trailers.Get("grpc-status"), "grpc-status must not be empty in trailers")
 	statusCode, err := strconv.Atoi(trailers.Get("grpc-status"))
 	require.NoError(s.T(), err, "no error parsing grpc-status")

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -357,6 +357,10 @@ func serializeProtoMessages(messages []proto.Message) [][]byte {
 func readTrailersFromBytes(t *testing.T, dataBytes []byte) grpcweb.Trailer {
 	bufferReader := bytes.NewBuffer(dataBytes)
 	tp := textproto.NewReader(bufio.NewReader(bufferReader))
+
+	// First, read bytes as MIME headers.
+	// However, it normalizes header names by textproto.CanonicalMIMEHeaderKey.
+	// In the next step, replace header names by raw one.
 	mimeHeader, err := tp.ReadMIMEHeader()
 	if err == nil {
 		return grpcweb.Trailer{}
@@ -365,6 +369,8 @@ func readTrailersFromBytes(t *testing.T, dataBytes []byte) grpcweb.Trailer {
 	trailers := make(http.Header)
 	bufferReader = bytes.NewBuffer(dataBytes)
 	tp = textproto.NewReader(bufio.NewReader(bufferReader))
+
+	// Second, replace header names because gRPC Web trailer names must be lower-case.
 	for {
 		line, err := tp.ReadLine()
 		if err == io.EOF {


### PR DESCRIPTION
As the result of a disscussion of https://github.com/improbable-eng/grpc-web/issues/228, we realized that we must use lower header/trailer names.
The changes maps header/trailer names to lower at the end of a request.