### PR TITLE
Add Automated Deploy Script to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,16 @@ install:
 before_script:
   - ./integration_test/start-testserver.sh &
 script:
-  - ./lint-all.sh
-  - travis_retry npm run test
+  - npm run test
+
+stages:
+  - lint
+  - test
+  - deploy
+
+jobs:
+  include:
+    - stage: lint
+      script: ./lint-all.sh
+    - stage: deploy
+      script: echo OK

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,5 @@ jobs:
     - stage: lint
       script: ./lint-all.sh
     - stage: deploy
-      script: echo OK
+      if: tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      script: echo Releasing $TRAVIS_TAG


### PR DESCRIPTION
This PR adds two new build stages:

- lint: executes before the 'test' stage to ensure that only one build will fail if there are linting errors
- deploy: executes after the 'test' stage if the tag matches a sem-ver release.

Note that the 'default' travis stage (test) has not been modified so all integration tests continue to be executed in parallel.