### PR TITLE
gRPC web client middleware [WIP]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,15 +9,13 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 
-[*.js]
+[**.{js,ts}]
 indent_style = space
 indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-# editorconfig-tools is unable to ignore longs strings or urls
-max_line_length = null
 
 # Override for Makefile
 [{Makefile, makefile, GNUmakefile}]

--- a/client/grpc-web-client/README.md
+++ b/client/grpc-web-client/README.md
@@ -92,3 +92,4 @@ Refer to [grpc-web-node-http-transport](https://npmjs.com/package/grpc-web-node-
 * [Code Generation](docs/code-generation.md)
 * [Concepts](docs/concepts.md)
 * [Transport](docs/transport.md)
+* [Middleware](docs/middleware.md)

--- a/client/grpc-web-client/docs/middleware.md
+++ b/client/grpc-web-client/docs/middleware.md
@@ -1,0 +1,103 @@
+# grpc.Middleware & grpc.MiddlewareConstructor
+The grpc-client allows you to define a middleware for each client. The middleware is designed to allow you to observe the lifecycle of a request. A common use-case for a middleware is to log the state and duration request without affecting the request in any way.
+
+In order to make this possible, the following interfaces, with full typing support, are provided to help you construct a middleware:
+* `grpc.MiddlewareConstructor` - used to construct a request specific middleware. The `grpc.MiddlewareConstructor` must return a partial, or complete, implentation of the `grpc.Middleware` interface.
+* `grpc.Middleware` - the concrete set of methods which will be invoked during the lifecycle of a request.
+
+On a high level, the middleware can be used as follows:
+```javascript
+grpc.unary(BookService.GetBook, {
+  ...
+  // Middleware is optional. It allows you to take side effects when various request callbacks are triggered.
+  middleware: (descriptor, props) => {
+    console.log("middleware: request created", descriptor, props);
+
+    return {
+      onStart: metadata => console.log("middleware: request started", metadata),
+      onSend: (message: ProtobufMessage) => console.log("middleware: onSend", message.toObject()),
+      onFinishSend: () => console.log("middleware: onFinishSend"),
+      onClose: () => console.log("middleware: onClose"),
+      onHeaders: (headers: Metadata) => console.log("middleware: onHeaders", headers),
+      onMessage: (message: ProtobufMessage) => console.log("middleware: onMessage", message.toObject()),
+      onEnd: (status, statusMessage, trailers) => console.log("middleware: onEnd", status, statusMessage, trailers)
+    }
+  }
+  ...
+})
+```
+
+## API Docs:
+### grpc.MiddlewareConstructor
+```javascript
+interface MiddlewareConstructor<TypeOfRequest, TypeOfResponse, MethodDescriptor> {
+  (descriptor: MethodDescriptor, props: ClientRpcOptions): Partial<Middleware<TypeOfRequest, TypeOfResponse>>
+}
+```
+The interfaces defines a function used to construct a middleware. It mirrors the relevant signature for request invocation [(grpc.invoke)](./invoke.md)
+
+The interface allows for a partial, or complete, implementation of the `grpc.Middleware` interface to be returned by the constructor.
+
+A separate constructor for the middleware is needed to allow lifecycle methods of the request to be scoped to an intance of the middleware rather than be global, requiring unique references to join individual lifecycle invocations together.
+
+
+## Example:
+```javascript
+const middlewareConstructor: grpc.MiddlewareConstructor<GetBookRequest, Book> = (descriptor, props) => {
+  return new ExampleMiddleware(descriptor, props);
+};
+````
+
+### grpc.Middleware
+```javascript
+// Middleware is the canonical definition of a Middleware.
+export interface Middleware<
+  TRequest extends ProtobufMessage,
+  TResponse extends ProtobufMessage,
+> {
+  // onStart is invoked immediately before a request is initiated.
+  // onStart can modify the provided metadata object to attach additional headers.
+  onStart(metadata: Metadata): undefined;
+
+  // onSend is invoked immediately before a new message is send to the server
+  // from the client.
+  // onSend is invoked each time a message is sent to the server.
+  onSend(message: TRequest): undefined;
+
+  // onFinishSend is invoked immediately after onFinishSend is invoked on a request.
+  // onFinishSend is invoked at most once per request.
+  onFinishSend(): undefined;
+
+  // onHeaders is invoked immediately before onHeaders callback is triggered.
+  // onHeaders is only invoked once per request.
+  onHeaders(headers: Metadata): undefined;
+
+  // onMessage is invoked immediately before onMessage callback is triggered.
+  // onMessage is invoked once for each message received from the response.
+  onMessage(response: TResponse): undefined;
+
+  // onEnd is invoked immediately after the onEnd callback is triggered.
+  // onEnd is invoked once per request.
+  onEnd(status: Code, statusMessage: string, trailers: Metadata): undefined;
+
+  // onClose is invoked immediately after onClose is triggered on a request.
+  // onClose is invoked at most once per request.
+  onClose(): undefined;
+}
+```
+The above defines the interface for a middleware. Each request has at most one instance of a middleware.
+
+A partial implementation is supported. Any un-implemented methods will not affect the request or response in any way.
+
+## Example:
+```javascript
+const middleware = {
+  onStart: metadata => console.log("middleware: request started", metadata),
+  onSend: (message: ProtobufMessage) => console.log("middleware: onSend", message.toObject()),
+  onFinishSend: () => console.log("middleware: onFinishSend"),
+  onClose: () => console.log("middleware: onClose"),
+  onHeaders: (headers: Metadata) => console.log("middleware: onHeaders", headers),
+  onMessage: (message: ProtobufMessage) => console.log("middleware: onMessage", message.toObject()),
+  onEnd: (status, statusMessage, trailers) => console.log("middleware: onEnd", status, statusMessage, trailers)
+}
+````

--- a/client/grpc-web-client/src/client.ts
+++ b/client/grpc-web-client/src/client.ts
@@ -298,8 +298,8 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
     requestHeaders.set("content-type", "application/grpc-web+proto");
     requestHeaders.set("x-grpc-web", "1"); // Required for CORS handling
 
-    const middlewareHeaders = this.middleware.onStart(requestHeaders) || requestHeaders;
-    this.transport.start(middlewareHeaders);
+    this.middleware.onStart(requestHeaders);
+    this.transport.start(requestHeaders);
   }
 
   send(msg: TRequest) {

--- a/client/grpc-web-client/src/index.ts
+++ b/client/grpc-web-client/src/index.ts
@@ -10,6 +10,7 @@ import * as impUnary from "./unary";
 import * as impClient from "./client";
 import * as impService from "./service";
 import * as impMessage from "./message";
+import * as impMiddleware from "./middleware";
 
 export namespace grpc {
   export interface ProtobufMessageClass<T extends ProtobufMessage> extends impMessage.ProtobufMessageClass<T> {}
@@ -40,34 +41,45 @@ export namespace grpc {
 
   export interface Client<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> extends impClient.Client<TRequest, TResponse> {}
   export function client<
-      TRequest extends ProtobufMessage,
-      TResponse extends ProtobufMessage,
-      M extends MethodDefinition<TRequest, TResponse>,
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>,
   >(methodDescriptor: M, props: ClientRpcOptions<TRequest, TResponse, M>): Client<TRequest, TResponse> {
     return impClient.client(methodDescriptor, props);
   }
   export interface RpcOptions<TRequest extends ProtobufMessage,
-      TResponse extends ProtobufMessage,
-      M extends MethodDefinition<TRequest, TResponse>,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>,
   > extends impClient.RpcOptions<TRequest, TResponse, M> {}
   export interface ClientRpcOptions<TRequest extends ProtobufMessage,
-      TResponse extends ProtobufMessage,
-      M extends MethodDefinition<TRequest, TResponse>,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>,
   > extends impClient.ClientRpcOptions<TRequest, TResponse, M> {}
 
   export const invoke = impInvoke.invoke;
   export interface Request extends impInvoke.Request {}
   export interface InvokeRpcOptions<
-      TRequest extends ProtobufMessage,
-      TResponse extends ProtobufMessage,
-      M extends MethodDefinition<TRequest, TResponse>,
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>,
   > extends impInvoke.InvokeRpcOptions<TRequest, TResponse, M> {}
 
   export const unary = impUnary.unary;
   export interface UnaryOutput<TResponse extends ProtobufMessage> extends impUnary.UnaryOutput<TResponse> {}
   export interface UnaryRpcOptions<
-      TRequest extends ProtobufMessage,
-      TResponse extends ProtobufMessage,
-      M extends MethodDefinition<TRequest, TResponse>,
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>,
   > extends impUnary.UnaryRpcOptions<TRequest, TResponse, M> {}
+
+  export interface MiddlewareConstructor<
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>,
+  > extends impMiddleware.MiddlewareConstructor<TRequest, TResponse, M> {}
+  export interface Middleware<
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+  > extends impMiddleware.Middleware<TRequest, TResponse> {}
+
 }

--- a/client/grpc-web-client/src/index.ts
+++ b/client/grpc-web-client/src/index.ts
@@ -39,17 +39,35 @@ export namespace grpc {
   export import Metadata = BrowserHeaders;
 
   export interface Client<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> extends impClient.Client<TRequest, TResponse> {}
-  export function client<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends MethodDefinition<TRequest, TResponse>>(methodDescriptor: M, props: ClientRpcOptions): Client<TRequest, TResponse> {
+  export function client<
+      TRequest extends ProtobufMessage,
+      TResponse extends ProtobufMessage,
+      M extends MethodDefinition<TRequest, TResponse>,
+  >(methodDescriptor: M, props: ClientRpcOptions<TRequest, TResponse, M>): Client<TRequest, TResponse> {
     return impClient.client(methodDescriptor, props);
   }
-  export interface RpcOptions extends impClient.RpcOptions {}
-  export interface ClientRpcOptions extends impClient.ClientRpcOptions {}
+  export interface RpcOptions<TRequest extends ProtobufMessage,
+      TResponse extends ProtobufMessage,
+      M extends MethodDefinition<TRequest, TResponse>,
+  > extends impClient.RpcOptions<TRequest, TResponse, M> {}
+  export interface ClientRpcOptions<TRequest extends ProtobufMessage,
+      TResponse extends ProtobufMessage,
+      M extends MethodDefinition<TRequest, TResponse>,
+  > extends impClient.ClientRpcOptions<TRequest, TResponse, M> {}
 
   export const invoke = impInvoke.invoke;
   export interface Request extends impInvoke.Request {}
-  export interface InvokeRpcOptions<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> extends impInvoke.InvokeRpcOptions<TRequest, TResponse> {}
+  export interface InvokeRpcOptions<
+      TRequest extends ProtobufMessage,
+      TResponse extends ProtobufMessage,
+      M extends MethodDefinition<TRequest, TResponse>,
+  > extends impInvoke.InvokeRpcOptions<TRequest, TResponse, M> {}
 
   export const unary = impUnary.unary;
   export interface UnaryOutput<TResponse extends ProtobufMessage> extends impUnary.UnaryOutput<TResponse> {}
-  export interface UnaryRpcOptions<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> extends impUnary.UnaryRpcOptions<TRequest, TResponse> {}
+  export interface UnaryRpcOptions<
+      TRequest extends ProtobufMessage,
+      TResponse extends ProtobufMessage,
+      M extends MethodDefinition<TRequest, TResponse>,
+  > extends impUnary.UnaryRpcOptions<TRequest, TResponse, M> {}
 }

--- a/client/grpc-web-client/src/invoke.ts
+++ b/client/grpc-web-client/src/invoke.ts
@@ -8,7 +8,11 @@ export interface Request {
   close: () => void;
 }
 
-export interface InvokeRpcOptions<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> extends RpcOptions {
+export interface InvokeRpcOptions<
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>,
+> extends RpcOptions<TRequest, TResponse, M> {
   host: string;
   request: TRequest;
   metadata?: Metadata.ConstructorArg;
@@ -18,7 +22,11 @@ export interface InvokeRpcOptions<TRequest extends ProtobufMessage, TResponse ex
 }
 
 
-export function invoke<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends MethodDefinition<TRequest, TResponse>>(methodDescriptor: M, props: InvokeRpcOptions<TRequest, TResponse>): Request {
+export function invoke<
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>
+>(methodDescriptor: M, props: InvokeRpcOptions<TRequest, TResponse, M>): Request {
   if (methodDescriptor.requestStream) {
     throw new Error(".invoke cannot be used with client-streaming methods. Use .client instead.");
   }
@@ -28,6 +36,7 @@ export function invoke<TRequest extends ProtobufMessage, TResponse extends Proto
     host: props.host,
     transport: props.transport,
     debug: props.debug,
+    middleware: props.middleware,
   });
 
   if (props.onHeaders) {

--- a/client/grpc-web-client/src/middleware.ts
+++ b/client/grpc-web-client/src/middleware.ts
@@ -1,0 +1,92 @@
+import {Metadata} from "./metadata";
+import {ProtobufMessage} from "./message";
+import {Code} from "./Code";
+import {MethodDefinition} from "./service";
+import {ClientRpcOptions} from "./client";
+
+const noop = () => void 0;
+
+/*
+ * MiddlewareConstructor is used to construct a request specific middleware.
+ *
+ * MiddlewareConstructor must return a partial or complete implementation of
+ * a middleware in order to function correctly. The partial implementation
+ * will be merged with a default implementation which has no side effects.
+ */
+export type MiddlewareConstructor<TRequest extends ProtobufMessage,
+  TResponse extends ProtobufMessage,
+  M extends MethodDefinition<TRequest, TResponse>,
+> = (descriptor: M, props: ClientRpcOptions<TRequest, TResponse, M>) => Partial<Middleware<TRequest, TResponse>>;
+
+// Middleware is the canonical definition of a Middleware.
+export interface Middleware<
+  TRequest extends ProtobufMessage,
+  TResponse extends ProtobufMessage,
+> {
+  // onStart is invoked immediately before a request is initiated.
+  // onStart can return a modified set of Metadata which will be used
+  // to make the request instead of the original headers.
+  onStart(metadata: Metadata): Metadata | undefined;
+
+  // onSend is invoked immediately before a new message is send to the server
+  // from the client.
+  // onSend is invoked each time a message is sent to the server.
+  onSend(message: TRequest): void;
+
+  // onFinishSend is invoked immediately after onFinishSend is invoked on a request.
+  // onFinishSend is invoked at most once per request.
+  onFinishSend(): void;
+
+  // onHeaders is invoked immediately before onHeaders callback is triggered.
+  // onHeaders is only invoked once per request.
+  onHeaders(headers: Metadata): void;
+
+  // onMessage is invoked immediately before onMessage callback is triggered.
+  // onMessage is invoked once for each message received from the response.
+  onMessage(response: TResponse): void;
+
+  // onEnd is invoked immediately after the onEnd callback is triggered.
+  // onEnd is invoked once per request.
+  onEnd(status: Code, statusMessage: string, trailers: Metadata): void;
+
+  // onClose is invoked immediately after onClose is triggered on a request.
+  // onClose is invoked at most once per request.
+  onClose(): void;
+}
+
+// IdentityMiddleware is a no-operation default middleware.
+// IdentityMiddleware is merged with any provided implementation.
+export const IdentityMiddleware: Middleware<any, any> = {
+  onStart: noop,
+  onSend: noop,
+  onFinishSend: noop,
+  onClose: noop,
+  onMessage: noop,
+  onHeaders: noop,
+  onEnd: noop,
+};
+
+// export const debugMiddleware = newMiddleware({
+//   onStart: metadata => {
+//     debug("Request started", metadata)
+//     return metadata;
+//   },
+//   onSend: (message: ProtobufMessage) => {
+//     debug("onSend", message.toObject())
+//     return message;
+//   },
+//   onFinishSend: () => debug("onFinishSend"),
+//   onClose: () => debug("onClose"),
+//   onHeaders: (headers: Metadata) => {
+//     debug("onHeaders", headers);
+//     return headers;
+//   },
+//   onMessage: (message: ProtobufMessage) => {
+//     debug("onMessage", message.toObject());
+//     return message;
+//   },
+//   onEnd: (status, statusMessage, trailers) => {
+//     debug("onEnd", status, statusMessage, trailers);
+//     return [status, statusMessage, trailers];
+//   }
+// })

--- a/client/grpc-web-client/src/middleware.ts
+++ b/client/grpc-web-client/src/middleware.ts
@@ -13,10 +13,13 @@ const noop = () => void 0;
  * a middleware in order to function correctly. The partial implementation
  * will be merged with a default implementation which has no side effects.
  */
-export type MiddlewareConstructor<TRequest extends ProtobufMessage,
+export interface MiddlewareConstructor<
+  TRequest extends ProtobufMessage,
   TResponse extends ProtobufMessage,
   M extends MethodDefinition<TRequest, TResponse>,
-> = (descriptor: M, props: ClientRpcOptions<TRequest, TResponse, M>) => Partial<Middleware<TRequest, TResponse>>;
+> {
+  (descriptor: M, props: ClientRpcOptions<TRequest, TResponse, M>): Partial<Middleware<TRequest, TResponse>>
+}
 
 // Middleware is the canonical definition of a Middleware.
 export interface Middleware<

--- a/client/grpc-web-client/src/middleware.ts
+++ b/client/grpc-web-client/src/middleware.ts
@@ -29,7 +29,7 @@ export interface Middleware<
   // onStart is invoked immediately before a request is initiated.
   // onStart can return a modified set of Metadata which will be used
   // to make the request instead of the original headers.
-  onStart(metadata: Metadata): Metadata | undefined;
+  onStart(metadata: Metadata): Metadata | undefined | void;
 
   // onSend is invoked immediately before a new message is send to the server
   // from the client.

--- a/client/grpc-web-client/src/middleware.ts
+++ b/client/grpc-web-client/src/middleware.ts
@@ -68,28 +68,3 @@ export const IdentityMiddleware: Middleware<any, any> = {
   onHeaders: noop,
   onEnd: noop,
 };
-
-// export const debugMiddleware = newMiddleware({
-//   onStart: metadata => {
-//     debug("Request started", metadata)
-//     return metadata;
-//   },
-//   onSend: (message: ProtobufMessage) => {
-//     debug("onSend", message.toObject())
-//     return message;
-//   },
-//   onFinishSend: () => debug("onFinishSend"),
-//   onClose: () => debug("onClose"),
-//   onHeaders: (headers: Metadata) => {
-//     debug("onHeaders", headers);
-//     return headers;
-//   },
-//   onMessage: (message: ProtobufMessage) => {
-//     debug("onMessage", message.toObject());
-//     return message;
-//   },
-//   onEnd: (status, statusMessage, trailers) => {
-//     debug("onEnd", status, statusMessage, trailers);
-//     return [status, statusMessage, trailers];
-//   }
-// })

--- a/client/grpc-web-client/src/middleware.ts
+++ b/client/grpc-web-client/src/middleware.ts
@@ -4,7 +4,7 @@ import {Code} from "./Code";
 import {MethodDefinition} from "./service";
 import {ClientRpcOptions} from "./client";
 
-const noop = () => void 0;
+const noop = () => undefined;
 
 /*
  * MiddlewareConstructor is used to construct a request specific middleware.
@@ -27,34 +27,33 @@ export interface Middleware<
   TResponse extends ProtobufMessage,
 > {
   // onStart is invoked immediately before a request is initiated.
-  // onStart can return a modified set of Metadata which will be used
-  // to make the request instead of the original headers.
-  onStart(metadata: Metadata): Metadata | undefined | void;
+  // onStart can modify the provided metadata object to attach additional headers.
+  onStart(metadata: Metadata): undefined;
 
   // onSend is invoked immediately before a new message is send to the server
   // from the client.
   // onSend is invoked each time a message is sent to the server.
-  onSend(message: TRequest): void;
+  onSend(message: TRequest): undefined;
 
   // onFinishSend is invoked immediately after onFinishSend is invoked on a request.
   // onFinishSend is invoked at most once per request.
-  onFinishSend(): void;
+  onFinishSend(): undefined;
 
   // onHeaders is invoked immediately before onHeaders callback is triggered.
   // onHeaders is only invoked once per request.
-  onHeaders(headers: Metadata): void;
+  onHeaders(headers: Metadata): undefined;
 
   // onMessage is invoked immediately before onMessage callback is triggered.
   // onMessage is invoked once for each message received from the response.
-  onMessage(response: TResponse): void;
+  onMessage(response: TResponse): undefined;
 
   // onEnd is invoked immediately after the onEnd callback is triggered.
   // onEnd is invoked once per request.
-  onEnd(status: Code, statusMessage: string, trailers: Metadata): void;
+  onEnd(status: Code, statusMessage: string, trailers: Metadata): undefined;
 
   // onClose is invoked immediately after onClose is triggered on a request.
   // onClose is invoked at most once per request.
-  onClose(): void;
+  onClose(): undefined;
 }
 
 // IdentityMiddleware is a no-operation default middleware.

--- a/client/grpc-web-client/src/unary.ts
+++ b/client/grpc-web-client/src/unary.ts
@@ -1,6 +1,6 @@
 import {Metadata} from "./metadata";
 import {Code} from "./Code";
-import {UnaryMethodDefinition} from "./service";
+import {MethodDefinition, UnaryMethodDefinition} from "./service";
 import {Request} from "./invoke";
 import {client, RpcOptions} from "./client";
 import {ProtobufMessage} from "./message";
@@ -13,14 +13,22 @@ export interface UnaryOutput<TResponse> {
   trailers: Metadata;
 }
 
-export interface UnaryRpcOptions<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage> extends RpcOptions {
+export interface UnaryRpcOptions<
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+    M extends MethodDefinition<TRequest, TResponse>,
+> extends RpcOptions<TRequest, TResponse, M> {
   host: string;
   request: TRequest;
   metadata?: Metadata.ConstructorArg;
   onEnd: (output: UnaryOutput<TResponse>) => void;
 }
 
-export function unary<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends UnaryMethodDefinition<TRequest, TResponse>>(methodDescriptor: M, props: UnaryRpcOptions<TRequest, TResponse>): Request {
+export function unary<
+    TRequest extends ProtobufMessage,
+    TResponse extends ProtobufMessage,
+    M extends UnaryMethodDefinition<TRequest, TResponse>,
+>(methodDescriptor: M, props: UnaryRpcOptions<TRequest, TResponse, M>): Request {
   if (methodDescriptor.responseStream) {
     throw new Error(".unary cannot be used with server-streaming methods. Use .invoke or .client instead.");
   }
@@ -35,6 +43,7 @@ export function unary<TRequest extends ProtobufMessage, TResponse extends Protob
     host: props.host,
     transport: props.transport,
     debug: props.debug,
+    middleware: props.middleware,
   });
   grpcClient.onHeaders((headers: Metadata) => {
     responseHeaders = headers;

--- a/client/grpc-web-react-example/ts/src/index.ts
+++ b/client/grpc-web-react-example/ts/src/index.ts
@@ -1,6 +1,8 @@
 import {grpc} from "grpc-web-client";
 import {BookService} from "../_proto/examplecom/library/book_service_pb_service";
 import {QueryBooksRequest, Book, GetBookRequest} from "../_proto/examplecom/library/book_service_pb";
+import {ProtobufMessage} from "grpc-web-client/src/message";
+import {Metadata} from "grpc-web-client/src/metadata";
 
 declare const USE_TLS: boolean;
 const host = USE_TLS ? "https://localhost:9091" : "http://localhost:9090";
@@ -11,6 +13,20 @@ function getBook() {
   grpc.unary(BookService.GetBook, {
     request: getBookRequest,
     host: host,
+    // Middleware is optional. It allows you to take side effects when various request callbacks are triggered.
+    middleware: (descriptor, props) => {
+      console.log("middleware: request created", descriptor, props);
+
+      return {
+        onStart: metadata => console.log("middleware: request started", metadata),
+        onSend: (message: ProtobufMessage) => console.log("middleware: onSend", message.toObject()),
+        onFinishSend: () => console.log("middleware: onFinishSend"),
+        onClose: () => console.log("middleware: onClose"),
+        onHeaders: (headers: Metadata) => console.log("middleware: onHeaders", headers),
+        onMessage: (message: ProtobufMessage) => console.log("middleware: onMessage", message.toObject()),
+        onEnd: (status, statusMessage, trailers) => console.log("middleware: onEnd", status, statusMessage, trailers)
+        }
+    },
     onEnd: res => {
       const { status, statusMessage, headers, message, trailers } = res;
       console.log("getBook.onEnd.status", status, statusMessage);

--- a/integration_test/ts/src/middleware.ts
+++ b/integration_test/ts/src/middleware.ts
@@ -1,0 +1,56 @@
+import {grpc} from "grpc-web-client";
+
+export class TestMiddleware implements grpc.Middleware<any, any> {
+
+  public calls: {
+    descriptor?: any;
+    props?: any;
+    onClose?: boolean;
+    onEnd?: [grpc.Code, string, grpc.Metadata];
+    onFinishSend?: boolean;
+    onHeaders?: grpc.Metadata;
+    onMessage?: any;
+    onSend?: any;
+    onStart?: grpc.Metadata;
+  };
+
+  constructor(descriptor: any, props: any) {
+    this.calls = {descriptor, props};
+  }
+
+  onClose(): undefined {
+    this.calls.onClose = true;
+    return undefined;
+  }
+
+  onEnd(status: grpc.Code, statusMessage: string, trailers: grpc.Metadata): undefined {
+    this.calls.onEnd = [status, statusMessage, trailers];
+    return undefined;
+  }
+
+  onFinishSend(): undefined {
+    this.calls.onFinishSend = true;
+    return undefined;
+  }
+
+  onHeaders(headers: grpc.Metadata): undefined {
+    this.calls.onHeaders = headers;
+    return undefined;
+  }
+
+  onMessage(response: any): undefined {
+    this.calls.onMessage = response;
+    return undefined;
+  }
+
+  onSend(message: any): undefined {
+    this.calls.onSend = message;
+    return undefined;
+  }
+
+  onStart(metadata: grpc.Metadata): undefined {
+    this.calls.onStart = metadata;
+    return undefined;
+  }
+
+}


### PR DESCRIPTION
An implementation of the middleware pattern for the grpc-web-client.

* A middleware allows requests to be intercepted and side-effects performed, ie *logging* or *timing*
* Allows for a browser extension to be built acting as a middleware to show deserialized payloads, similar to Chrome's Network tab

Remaining TODO:
* [x] Tests
* [x] Example
* [x] Documentation

Due to the type change on the request properties, this should be assumed to be a non-backwards compatible change and will require bumping of a major (pre-1.0) version