### PR TITLE
Provide hook to add values to context from websocket connection headers

### DIFF
--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -3,7 +3,10 @@
 
 package grpcweb
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 var (
 	defaultOptions = &options{
@@ -19,6 +22,7 @@ type options struct {
 	originFunc                     func(origin string) bool
 	enableWebsockets               bool
 	websocketOriginFunc            func(req *http.Request) bool
+	websocketContextInterceptor    func(ctx context.Context, header http.Header) context.Context
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -97,5 +101,12 @@ func WithWebsockets(enableWebsockets bool) Option {
 func WithWebsocketOriginFunc(websocketOriginFunc func(req *http.Request) bool) Option {
 	return func(o *options) {
 		o.websocketOriginFunc = websocketOriginFunc
+	}
+}
+
+// WithWebsocketContextInterceptor provides a hook to add values to context by using headers from websocket connection
+func WithWebsocketContextInterceptor(websocketContextInterceptor func(ctx context.Context, req http.Header) context.Context) Option {
+	return func(o *options) {
+		o.websocketContextInterceptor = websocketContextInterceptor
 	}
 }


### PR DESCRIPTION
I may be missing something, but I haven't been able to find another way to access the headers sent over the websocket connection in my service implementation on the server.

I've made a hook to access the headers after they are parsed by the wrapper and added values, in my case a session token, to the context.

```go
...
wrappedGrpc = grpcweb.WrapServer(grpcServer, grpcweb.WithWebsocketContextInterceptor(wsContextInterceptor))
...

func wsContextInterceptor(c ctx.Context, header http.Header) ctx.Context {
	token := header.Get(tokenHeaderKey)
	if token != "" {
		c = ctx.WithValue(c, tokenHeaderKey, token)
	}
	return c
}
```