### PR TITLE
Update to latest gRPC: 1.17.0; Update deps and tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
+  digest = "1:66c4f0faff05a23bbb921be3f21838d7d58e69f4d102e23347ea8080675d1efa"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -37,7 +37,7 @@
     "ptypes/timestamp",
   ]
   pruneopts = ""
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "1d3f30b51784bec5aad268e59fd3c2fc1c2fe73f"
 
 [[projects]]
   digest = "1:64d212c703a2b94054be0ce470303286b177ad260b2f89a307e3d1bb6c073ef6"
@@ -90,11 +90,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:aeb8a3a567f276057a448c3adc2e677df0642ea21cc7b95582af13a218653436"
+  digest = "1:ddd2a3fe8c4dd178ba026bccfc146aba366b55c2db113ddf7d0fd90278dfeeb7"
   name = "github.com/mwitkow/grpc-proxy"
   packages = ["proxy"]
   pruneopts = ""
-  revision = "67591eb23c48346a480470e462289835d96f70da"
+  revision = "0f1106ef9c766333b9acb4b81e705da4bade7215"
 
 [[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
@@ -249,35 +249,44 @@
   revision = "73cb5d0be5af113b42057925bd6c93e3cd9f60fd"
 
 [[projects]]
-  digest = "1:6c00b4702c146631d30396090d40bfc0486f8b3af5c976d6f0daf2bc737cd7b2"
+  digest = "1:d141efe4aaad714e3059c340901aab3147b6253e58c85dafbcca3dd8b0e88ad6"
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
+    "balancer/base",
     "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
     "codes",
     "connectivity",
     "credentials",
+    "credentials/internal",
     "encoding",
-    "grpclb/grpc_lb_v1/messages",
+    "encoding/proto",
     "grpclog",
     "internal",
+    "internal/backoff",
+    "internal/binarylog",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
     "peer",
     "resolver",
     "resolver/dns",
-    "resolver/manual",
     "resolver/passthrough",
     "stats",
     "status",
     "tap",
-    "transport",
   ]
   pruneopts = ""
-  revision = "be077907e29fdb945d351e4284eb5361e7f8924e"
-  version = "v1.8.1"
+  revision = "df014850f6dee74ba2fc94874043a9f3f75fbfd8"
+  version = "v1.17.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -308,7 +317,6 @@
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/grpclog",
     "google.golang.org/grpc/metadata",
-    "google.golang.org/grpc/transport",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -208,14 +208,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:214861987138c7a919536c43586058258d6dd935d3dff0aed48855f211c732ee"
+  digest = "1:e6d1805ead5b8f2439808f76187f54042ed35ee26eb9ca63127259a0e612b119"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = ""
-  revision = "b8f5ef32195cae6470b728e8ca677f0dbed1a004"
+  revision = "b4a75ba826a64a70990f11a225237acd6ef35c9f"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,4 +52,4 @@ required = [
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "1.8.0"
+  version = "1.17.0"

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -254,8 +254,11 @@ func (s *GrpcWebWrapperTestSuite) TestPingList_NormalGrpcWorks() {
 	}
 	recvHeaders, err := pingListClient.Header()
 	require.NoError(s.T(), err, "no error during execution")
+	assert.Equal(s.T(), len(expectedHeaders)+2 /*trailers content-type*/, len(recvHeaders), "expected headers must be received")
+	assert.Equal(s.T(), recvHeaders.Get("Content-Type"), []string{"application/grpc"})
+	assert.Contains(s.T(), recvHeaders, "trailer")
+
 	recvTrailers := pingListClient.Trailer()
-	assert.Equal(s.T(), len(expectedHeaders)+1 /*trailers*/, len(recvHeaders), "expected headers must be received")
 	assert.EqualValues(s.T(), expectedTrailers, recvTrailers, "expected trailers must be received")
 }
 
@@ -274,8 +277,11 @@ func (s *GrpcWebWrapperTestSuite) TestPingStream_NormalGrpcWorks() {
 	assert.Equal(s.T(), "one,two", resp.GetValue(), "expected concatenated value must be received")
 	recvHeaders, err := bidiClient.Header()
 	require.NoError(s.T(), err, "no error during execution")
+	assert.Equal(s.T(), len(expectedHeaders)+2 /*trailers content-type*/, len(recvHeaders), "expected headers must be received")
+	assert.Equal(s.T(), recvHeaders.Get("Content-Type"), []string{"application/grpc"})
+	assert.Contains(s.T(), recvHeaders, "trailer")
+
 	recvTrailers := bidiClient.Trailer()
-	assert.Equal(s.T(), len(expectedHeaders)+1 /*trailers*/, len(recvHeaders), "expected headers must be received")
 	assert.EqualValues(s.T(), expectedTrailers, recvTrailers, "expected trailers must be received")
 }
 


### PR DESCRIPTION
Update the latest gRPC release. This required updating protobuf,
github.com/mwitkow/grpc-proxy and required a few test changes.

wrapper_test: when the tests were written, the native gRPC response headers
would only include "trailers" and the two explicitly set headers. Now it
also contains a "content-type" header.

integration_test testserver: Some gRPC internals were moved around.