### PR TITLE
Update all child packages to reference @improbable-eng/grpc-web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0
+### Breaking Changes
+* Scoped npm package under the @improbable-eng org; consumers should now `npm install @improbable-eng/grpc-web`.
+
 ## 0.7.0
 ### Breaking Changes
 * Removed built-in support for NodeJS Environments; if you want to use `grpc-web-client` in a NodeJS environment you will need to import `grpc-web-node-http-transport` and specify it as your Default Transport.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ With gRPC-Web, it is extremely easy to build well-defined, easy to reason about 
 
 In short, gRPC-Web moves the interaction between frontend code and microservices from the sphere of hand-crafted HTTP requests to well-defined user-logic methods.
 
-## Client-side (grpc-web-client) Docs
+## Client-side (grpc-web) Docs
 
 **Note: You'll need to add gRPC-Web compatibility to your server through either [`grpcweb`](go/grpcweb) or [`grpcwebproxy`](go/grpcwebproxy).**
 
-[API Docs for `grpc-web-client` can be found here](./client/grpc-web-client)
+[API Docs for `grpc-web` client can be found here](./client/grpc-web)
 
 ## Example 
 
@@ -102,7 +102,7 @@ func (s *bookService) QueryBooks(bookQuery *pb_library.QueryBooksRequest, stream
 You will be able to access it in a browser using TypeScript (and equally JavaScript after transpiling):
 
 ```javascript
-import {grpc} from "grpc-web-client";
+import {grpc} from "@improbable-eng/grpc-web";
 
 // Import code-generated data structures.
 import {BookService} from "../_proto/examplecom/library/book_service_pb_service";
@@ -131,7 +131,7 @@ grpc.invoke(BookService.QueryBooks, {
 
 ## Browser Support
 
-The `grpc-web-client` uses multiple techniques to efficiently invoke gRPC services. Most modern browsers support the [Fetch API](https://developer.mozilla.org/en/docs/Web/API/Fetch_API), which allows for efficient reading of partial, binary responses. For older browsers, it automatically falls back to [`XMLHttpRequest`](https://developer.mozilla.org/nl/docs/Web/API/XMLHttpRequest).
+The `@improbable-eng/grpc-web` client uses multiple techniques to efficiently invoke gRPC services. Most modern browsers support the [Fetch API](https://developer.mozilla.org/en/docs/Web/API/Fetch_API), which allows for efficient reading of partial, binary responses. For older browsers, it automatically falls back to [`XMLHttpRequest`](https://developer.mozilla.org/nl/docs/Web/API/XMLHttpRequest).
 
 The gRPC semantics encourage you to make multiple requests at once. With most modern browsers [supporting HTTP2](http://caniuse.com/#feat=http2), these can be executed over a single TLS connection. For older browsers, gRPC-Web falls back to HTTP/1.1 chunk responses.
 
@@ -144,9 +144,9 @@ This library is tested against:
   
 ## Node.js Support
 
-`grpc-web-client` also [supports Node.js through a transport](./client/grpc-web/docs/transport.md#node-http-only-available-in-a-nodejs-environment) that uses the `http` and `https` packages. Usage does not vary from browser usage as transport is determined at runtime.
+The `@improbable-eng/grpc-web` client also [supports Node.js through a transport](./client/grpc-web/docs/transport.md#node-http-only-available-in-a-nodejs-environment) that uses the `http` and `https` packages. Usage does not vary from browser usage as transport is determined at runtime.
 
-If you want to use `grpc-web-client` in a node.js environment with Typescript, you must include `dom` in the `"lib"` Array in your `tsconfig.json` otherwise `tsc` will be unable to find some type declarations to compile. Note that `dom` will be included automatically if you do not declare `lib` in your configration and your target is one of `es5` or `es6`. (See [Typescript compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)).
+If you want to use the `@improbable-eng/grpc-web` client in a node.js environment with Typescript, you must include `dom` in the `"lib"` Array in your `tsconfig.json` otherwise `tsc` will be unable to find some type declarations to compile. Note that `dom` will be included automatically if you do not declare `lib` in your configration and your target is one of `es5` or `es6`. (See [Typescript compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)).
 
 ```
 {
@@ -171,7 +171,7 @@ This, however, is useful for a lot of frontend functionality.
 The code here is `alpha` quality. It is being used for a subset of Improbable's frontend single-page apps in production.
 
 ## Known Limitations
-See the grpc-web-client's Transport Documentation for [a list of Web Browser caveats](./client/grpc-web/docs/transport.md#http/2-based-transports).
+See the `@improbable-eng/grpc-web` client Transport Documentation for [a list of Web Browser caveats](./client/grpc-web/docs/transport.md#http/2-based-transports).
 
 ### Contributing
 See [CONTRIBUTING](./CONTRIBUTING.md)

--- a/client/grpc-web-node-http-transport/README.md
+++ b/client/grpc-web-node-http-transport/README.md
@@ -1,11 +1,11 @@
 # grpc-web-node-http-transport
-Node HTTP Transport for use with [grpc-web-client](https://github.com/improbable-eng/grpc-web)
+Node HTTP Transport for use with [@improbable-eng/grpc-web](https://github.com/improbable-eng/grpc-web)
 
 ## Usage
 When making a gRPC request, specify this transport:
 
 ```typescript
-import { grpc } from 'grpc-web-client';
+import { grpc } from '@improbable-eng/grpc-web';
 import { NodeHttpTransport } from 'grpc-web-node-http-transport';
 
 grpc.invoke(MyService.DoQuery, {
@@ -17,7 +17,7 @@ grpc.invoke(MyService.DoQuery, {
 
 Alternatively specify the Default Transport when your server/application bootstraps:
 ```typescript
-import { grpc } from "grpc-web-client";
+import { grpc } from "@improbable-eng/grpc-web";
 import { NodeHttpTransport } from "grpc-web-node-http-transport";
 
 // Do this first, before you make any grpc requests!

--- a/client/grpc-web-node-http-transport/package-lock.json
+++ b/client/grpc-web-node-http-transport/package-lock.json
@@ -10,19 +10,6 @@
       "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==",
       "dev": true
     },
-    "browser-headers": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
-      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
-    },
-    "grpc-web-client": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/grpc-web-client/-/grpc-web-client-0.7.0.tgz",
-      "integrity": "sha512-tydslNg6pPHi61aMs0HoaETTtyDR5TQyDZ0AQhbbURpOK2NW8IMrUGs/i1UMkS0H64Vj7PuggSAhDohP41yubQ==",
-      "requires": {
-        "browser-headers": "^0.4.0"
-      }
-    },
     "typescript": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",

--- a/client/grpc-web-node-http-transport/package.json
+++ b/client/grpc-web-node-http-transport/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grpc-web-node-http-transport",
   "version": "0.0.1",
-  "description": "Node HTTP Transport for use with grpc-web-client",
+  "description": "Node HTTP Transport for use with @improbable-eng/grpc-web",
   "main": "lib/index.js",
   "repository": {
     "type": "git",

--- a/client/grpc-web-node-http-transport/package.json
+++ b/client/grpc-web-node-http-transport/package.json
@@ -14,7 +14,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "grpc-web-client": "^0.7.0"
+    "@improbable-eng/grpc-web": "^0.8.0"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/client/grpc-web-node-http-transport/src/index.ts
+++ b/client/grpc-web-node-http-transport/src/index.ts
@@ -1,7 +1,7 @@
 import * as http from "http";
 import * as https from "https";
 import * as url from "url";
-import { grpc } from "grpc-web-client";
+import { grpc } from "@improbable-eng/grpc-web";
 
 export function NodeHttpTransport(): grpc.TransportFactory {
   return (opts: grpc.TransportOptions) => {

--- a/client/grpc-web-react-example/go/Gopkg.lock
+++ b/client/grpc-web-react-example/go/Gopkg.lock
@@ -3,48 +3,39 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f26d410f706e6bdfb1576cacf9e4bbd3add8b55a298bf90ab20f588854bad6e0"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "UT"
   revision = "d3de96c4c28ef8af3aa1a892fc481e0f103c01ff"
 
 [[projects]]
-  digest = "1:43dd08a10854b2056e615d1b1d22ac94559d822e1f8b6fcc92c1a1057e85188e"
   name = "github.com/gorilla/websocket"
   packages = ["."]
-  pruneopts = "UT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:0efd83767461e5110a8d397f68ad764ffe388132ee2376de7912801a4c7794a8"
   name = "github.com/improbable-eng/grpc-web"
   packages = [
     "example/go/_proto/examplecom/library",
-    "go/grpcweb",
+    "go/grpcweb"
   ]
-  pruneopts = "UT"
   revision = "72eb701d6f320ca324b3347c7925a720b553eae5"
   version = "0.6.2"
 
 [[projects]]
-  digest = "1:d2f8ec47e1957eaf4d4ea9ddfcb9b4c33771229104669e697ee07c9a9d54918e"
   name = "github.com/rs/cors"
   packages = ["."]
-  pruneopts = "UT"
   revision = "feef513b9575b32f84bafa580aad89b011259019"
   version = "v1.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:9349bd005ea80ec1b37032d01daedc81168348a9c295f7846188adfb2f405554"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -54,13 +45,11 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace",
+    "trace"
   ]
-  pruneopts = "UT"
   revision = "5f9ae10d9af5b1c89ae6904293b14b064d4ada23"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -76,22 +65,18 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:cd018653a358d4b743a9d3bee89e825521f2ab2f2ec0770164bf7632d8d73ab7"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  pruneopts = "UT"
   revision = "86e600f69ee4704c6efbf6a2a40a5c10700e76c2"
 
 [[projects]]
-  digest = "1:f47fb9bd1a9173285be23a1a1342e019abddfd787216e7f2c555ddba837e98ce"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -116,23 +101,14 @@
     "stats",
     "status",
     "tap",
-    "transport",
+    "transport"
   ]
-  pruneopts = "UT"
   revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
   version = "v1.11.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/improbable-eng/grpc-web/example/go/_proto/examplecom/library",
-    "github.com/improbable-eng/grpc-web/go/grpcweb",
-    "golang.org/x/net/context",
-    "google.golang.org/grpc",
-    "google.golang.org/grpc/codes",
-    "google.golang.org/grpc/grpclog",
-    "google.golang.org/grpc/metadata",
-  ]
+  inputs-digest = "8ef08c4d978ca0c1fa481e302579b513c76725cfbdea0faad298c94907564269"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/client/grpc-web-react-example/package-lock.json
+++ b/client/grpc-web-react-example/package-lock.json
@@ -647,11 +647,6 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
-    "browser-headers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.0.tgz",
-      "integrity": "sha1-e2tNPMDOzJ3fUDdoFHkyEFxCFzQ="
-    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -2618,14 +2613,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
-    },
-    "grpc-web-client": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/grpc-web-client/-/grpc-web-client-0.6.2.tgz",
-      "integrity": "sha512-7LSp9Gr0cWLJp53ijrNW+KHNyw8rZKDMMmFKmRkxu1QJLU9vuE+5hG4NTc8ao5YwuP1rsBQi74eZ1R+sOiQVtg==",
-      "requires": {
-        "browser-headers": "^0.4.0"
-      }
     },
     "handle-thing": {
       "version": "1.2.5",

--- a/client/grpc-web-react-example/package.json
+++ b/client/grpc-web-react-example/package.json
@@ -15,7 +15,7 @@
   "license": "none",
   "dependencies": {
     "google-protobuf": "^3.6.1",
-    "grpc-web-client": "^0.6.2"
+    "@improbable-eng/grpc-web": "^0.8.0"
   },
   "devDependencies": {
     "@types/google-protobuf": "^3.2.5",

--- a/client/grpc-web-react-example/ts/src/index.ts
+++ b/client/grpc-web-react-example/ts/src/index.ts
@@ -1,4 +1,4 @@
-import {grpc} from "grpc-web-client";
+import {grpc} from "@improbable-eng/grpc-web";
 import {BookService} from "../_proto/examplecom/library/book_service_pb_service";
 import {QueryBooksRequest, Book, GetBookRequest} from "../_proto/examplecom/library/book_service_pb";
 

--- a/client/grpc-web/docs/code-generation.md
+++ b/client/grpc-web/docs/code-generation.md
@@ -4,7 +4,7 @@ To make gRPC requests the client requires generated code for the [method definit
 
 [`protoc`](https://github.com/google/protobuf) is the google protobuf code generation tool. It can generate the JavaScript message classes and also supports using plugins for additional code generation.
 
-[`ts-protoc-gen`](https://www.github.com/improbable-eng/ts-protoc-gen) is a package that can generate the `.d.ts` files that declare the contents of the protoc-generated JavaScript files. `ts-protoc-gen` can also generate `grpc-web-client` service/method definitions with the `protoc-gen-ts` plugin and `service=true` argument.
+[`ts-protoc-gen`](https://www.github.com/improbable-eng/ts-protoc-gen) is a package that can generate the `.d.ts` files that declare the contents of the protoc-generated JavaScript files. `ts-protoc-gen` can also generate `@improbable-eng/grpc-web` client service/method definitions with the `protoc-gen-ts` plugin and `service=true` argument.
 
 This is an example of a complete invokation of `protoc` with `ts-protoc-gen` assuming your `.proto` files are in a directory named `my-protos` within the current working directory:
 

--- a/integration_test/package-lock.json
+++ b/integration_test/package-lock.json
@@ -3574,14 +3574,6 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
-    "grpc-web-client": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/grpc-web-client/-/grpc-web-client-0.7.0.tgz",
-      "integrity": "sha512-tydslNg6pPHi61aMs0HoaETTtyDR5TQyDZ0AQhbbURpOK2NW8IMrUGs/i1UMkS0H64Vj7PuggSAhDohP41yubQ==",
-      "requires": {
-        "browser-headers": "^0.4.0"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",

--- a/integration_test/package.json
+++ b/integration_test/package.json
@@ -22,7 +22,7 @@
     "browser-headers": "^0.4.0",
     "event-stream": "^3.3.4",
     "google-protobuf": "^3.2.0",
-    "grpc-web-client": "^0.7.0",
+    "@improbable-eng/grpc-web": "^0.8.0",
     "grpc-web-node-http-transport": "^0.0.1",
     "typedarray": "0.0.6"
   },

--- a/integration_test/ts/src/cancellation.spec.ts
+++ b/integration_test/ts/src/cancellation.spec.ts
@@ -1,7 +1,7 @@
 // gRPC-Web library
 import {
   grpc,
-} from "grpc-web-client";
+} from "@improbable-eng/grpc-web";
 
 import {debug} from "../../../client/grpc-web/src/debug";
 import {assert} from "chai";

--- a/integration_test/ts/src/client.spec.ts
+++ b/integration_test/ts/src/client.spec.ts
@@ -1,5 +1,5 @@
 // gRPC-Web library
-import {grpc} from "grpc-web-client";
+import {grpc} from "@improbable-eng/grpc-web";
 
 import {debug} from "../../../client/grpc-web/src/debug";
 import {assert} from "chai";

--- a/integration_test/ts/src/client.websocket.spec.ts
+++ b/integration_test/ts/src/client.websocket.spec.ts
@@ -1,5 +1,5 @@
 // gRPC-Web library
-import { grpc } from "grpc-web-client";
+import { grpc } from "@improbable-eng/grpc-web";
 
 import { debug } from "../../../client/grpc-web/src/debug";
 import { assert } from "chai";

--- a/integration_test/ts/src/invoke.spec.ts
+++ b/integration_test/ts/src/invoke.spec.ts
@@ -1,7 +1,7 @@
 // gRPC-Web library
 import {
   grpc,
-} from "grpc-web-client";
+} from "@improbable-eng/grpc-web";
 
 import {debug} from "../../../client/grpc-web/src/debug";
 import {assert} from "chai";

--- a/integration_test/ts/src/testRpcCombinations.ts
+++ b/integration_test/ts/src/testRpcCombinations.ts
@@ -2,7 +2,7 @@ import {
   testHost,
   corsHost
 } from "../../hosts-config";
-import {grpc} from "grpc-web-client";
+import {grpc} from "@improbable-eng/grpc-web";
 import {NodeHttpTransport} from "grpc-web-node-http-transport";
 
 type TestConfig = {

--- a/integration_test/ts/src/unary.spec.ts
+++ b/integration_test/ts/src/unary.spec.ts
@@ -1,7 +1,7 @@
 // gRPC-Web library
 import {
   grpc,
-} from "grpc-web-client";
+} from "@improbable-eng/grpc-web";
 
 import {debug} from "../../../client/grpc-web/src/debug";
 import {assert} from "chai";

--- a/integration_test/ts/src/util.ts
+++ b/integration_test/ts/src/util.ts
@@ -2,7 +2,7 @@ import {ContinueStreamRequest} from "../_proto/improbable/grpcweb/test/test_pb";
 import {TestUtilService} from "../_proto/improbable/grpcweb/test/test_pb_service";
 import {
   grpc,
-} from "grpc-web-client";
+} from "@improbable-eng/grpc-web";
 
 export const DEBUG: boolean = (global as any).DEBUG;
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "grpc-web-ci",
+  "private": true,
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap",


### PR DESCRIPTION
Part of #289; this PR aims to remove all references to the `grpc-web-client` package from the monorepo.
