### PR TITLE
Upgrade ts-protoc-gen to 0.9.0

### DIFF
--- a/integration_test/package-lock.json
+++ b/integration_test/package-lock.json
@@ -6497,13 +6497,9 @@
       }
     },
     "ts-protoc-gen": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.7.6.tgz",
-      "integrity": "sha512-PW0kzZT3jwqh1VE8Lijd9AOV4o1g9lUlHo4yyb/KDvMN5CZLyAlng/chWWyxYpGLxKY+8NsWDIqkeI7w2yRoJw==",
-      "dev": true,
-      "requires": {
-        "google-protobuf": "^3.5.0"
-      }
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.9.0.tgz",
+      "integrity": "sha512-cFEUTY9U9o6C4DPPfMHk2ZUdIAKL91hZN1fyx5Stz3g56BDVOC7hk+r5fEMCAGaaIgi2akkT1a2hrxu1wo2Phg=="
     },
     "tslib": {
       "version": "1.9.3",

--- a/integration_test/package.json
+++ b/integration_test/package.json
@@ -19,11 +19,12 @@
   },
   "license": "none",
   "dependencies": {
+    "@improbable-eng/grpc-web": "^0.8.0",
     "browser-headers": "^0.4.0",
     "event-stream": "^3.3.4",
     "google-protobuf": "^3.2.0",
-    "@improbable-eng/grpc-web": "^0.8.0",
     "grpc-web-node-http-transport": "^0.0.1",
+    "ts-protoc-gen": "^0.9.0",
     "typedarray": "0.0.6"
   },
   "devDependencies": {
@@ -49,7 +50,6 @@
     "lodash": "^4.17.10",
     "ts-loader": "^4.2.0",
     "ts-node": "^7.0.1",
-    "ts-protoc-gen": "0.7.6",
     "typescript": "3.0.1",
     "wd": "^1.6.2",
     "webpack": "^4.6.0",

--- a/integration_test/ts/_proto/improbable/grpcweb/test/test_pb_service.d.ts
+++ b/integration_test/ts/_proto/improbable/grpcweb/test/test_pb_service.d.ts
@@ -3,7 +3,7 @@
 
 import * as improbable_grpcweb_test_test_pb from "../../../improbable/grpcweb/test/test_pb";
 import * as google_protobuf_empty_pb from "google-protobuf/google/protobuf/empty_pb";
-import {grpc} from "grpc-web-client";
+import {grpc} from "@improbable-eng/grpc-web";
 
 type TestServicePingEmpty = {
   readonly methodName: string;
@@ -119,96 +119,113 @@ export class FailService {
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
 export type Status = { details: string, code: number; metadata: grpc.Metadata }
-export type ServiceClientOptions = { transport: grpc.TransportConstructor; debug?: boolean }
 
+interface UnaryResponse {
+  cancel(): void;
+}
 interface ResponseStream<T> {
   cancel(): void;
   on(type: 'data', handler: (message: T) => void): ResponseStream<T>;
   on(type: 'end', handler: () => void): ResponseStream<T>;
   on(type: 'status', handler: (status: Status) => void): ResponseStream<T>;
 }
+interface RequestStream<T> {
+  write(message: T): RequestStream<T>;
+  end(): void;
+  cancel(): void;
+  on(type: 'end', handler: () => void): RequestStream<T>;
+  on(type: 'status', handler: (status: Status) => void): RequestStream<T>;
+}
+interface BidirectionalStream<ReqT, ResT> {
+  write(message: ReqT): BidirectionalStream<ReqT, ResT>;
+  end(): void;
+  cancel(): void;
+  on(type: 'data', handler: (message: ResT) => void): BidirectionalStream<ReqT, ResT>;
+  on(type: 'end', handler: () => void): BidirectionalStream<ReqT, ResT>;
+  on(type: 'status', handler: (status: Status) => void): BidirectionalStream<ReqT, ResT>;
+}
 
 export class TestServiceClient {
   readonly serviceHost: string;
 
-  constructor(serviceHost: string, options?: ServiceClientOptions);
+  constructor(serviceHost: string, options?: grpc.RpcOptions);
   pingEmpty(
     requestMessage: google_protobuf_empty_pb.Empty,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
+  ): UnaryResponse;
   pingEmpty(
     requestMessage: google_protobuf_empty_pb.Empty,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
+  ): UnaryResponse;
   ping(
     requestMessage: improbable_grpcweb_test_test_pb.PingRequest,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
+  ): UnaryResponse;
   ping(
     requestMessage: improbable_grpcweb_test_test_pb.PingRequest,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
+  ): UnaryResponse;
   pingError(
     requestMessage: improbable_grpcweb_test_test_pb.PingRequest,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: google_protobuf_empty_pb.Empty|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: google_protobuf_empty_pb.Empty|null) => void
+  ): UnaryResponse;
   pingError(
     requestMessage: improbable_grpcweb_test_test_pb.PingRequest,
-    callback: (error: ServiceError, responseMessage: google_protobuf_empty_pb.Empty|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: google_protobuf_empty_pb.Empty|null) => void
+  ): UnaryResponse;
   pingList(requestMessage: improbable_grpcweb_test_test_pb.PingRequest, metadata?: grpc.Metadata): ResponseStream<improbable_grpcweb_test_test_pb.PingResponse>;
-  pingPongBidi(): void;
-  pingStream(): void;
+  pingPongBidi(metadata?: grpc.Metadata): BidirectionalStream<improbable_grpcweb_test_test_pb.PingRequest, improbable_grpcweb_test_test_pb.PingResponse>;
+  pingStream(metadata?: grpc.Metadata): RequestStream<improbable_grpcweb_test_test_pb.PingRequest>;
   echo(
     requestMessage: improbable_grpcweb_test_test_pb.TextMessage,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.TextMessage|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.TextMessage|null) => void
+  ): UnaryResponse;
   echo(
     requestMessage: improbable_grpcweb_test_test_pb.TextMessage,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.TextMessage|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.TextMessage|null) => void
+  ): UnaryResponse;
 }
 
 export class TestUtilServiceClient {
   readonly serviceHost: string;
 
-  constructor(serviceHost: string, options?: ServiceClientOptions);
+  constructor(serviceHost: string, options?: grpc.RpcOptions);
   continueStream(
     requestMessage: improbable_grpcweb_test_test_pb.ContinueStreamRequest,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: google_protobuf_empty_pb.Empty|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: google_protobuf_empty_pb.Empty|null) => void
+  ): UnaryResponse;
   continueStream(
     requestMessage: improbable_grpcweb_test_test_pb.ContinueStreamRequest,
-    callback: (error: ServiceError, responseMessage: google_protobuf_empty_pb.Empty|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: google_protobuf_empty_pb.Empty|null) => void
+  ): UnaryResponse;
   checkStreamClosed(
     requestMessage: improbable_grpcweb_test_test_pb.CheckStreamClosedRequest,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.CheckStreamClosedResponse|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.CheckStreamClosedResponse|null) => void
+  ): UnaryResponse;
   checkStreamClosed(
     requestMessage: improbable_grpcweb_test_test_pb.CheckStreamClosedRequest,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.CheckStreamClosedResponse|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.CheckStreamClosedResponse|null) => void
+  ): UnaryResponse;
 }
 
 export class FailServiceClient {
   readonly serviceHost: string;
 
-  constructor(serviceHost: string, options?: ServiceClientOptions);
+  constructor(serviceHost: string, options?: grpc.RpcOptions);
   nonExistant(
     requestMessage: improbable_grpcweb_test_test_pb.PingRequest,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
+  ): UnaryResponse;
   nonExistant(
     requestMessage: improbable_grpcweb_test_test_pb.PingRequest,
-    callback: (error: ServiceError, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
-  ): void;
+    callback: (error: ServiceError|null, responseMessage: improbable_grpcweb_test_test_pb.PingResponse|null) => void
+  ): UnaryResponse;
 }
 


### PR DESCRIPTION
Part of #290; the service clients code-generated by the integration tests now reference `@improbable-eng/grpc-web`. Note that this wasn't a problem before as the gprc-web integration tests don't actually use the service clients.
