### PR TITLE
Migrate grpc-web-node-http-transport package so it's under the @improbable-eng org. on npm.

### DIFF
--- a/client/grpc-web-node-http-transport/README.md
+++ b/client/grpc-web-node-http-transport/README.md
@@ -1,4 +1,4 @@
-# grpc-web-node-http-transport
+# @improbable-eng/grpc-web-node-http-transport
 Node HTTP Transport for use with [@improbable-eng/grpc-web](https://github.com/improbable-eng/grpc-web)
 
 ## Usage
@@ -6,7 +6,7 @@ When making a gRPC request, specify this transport:
 
 ```typescript
 import { grpc } from '@improbable-eng/grpc-web';
-import { NodeHttpTransport } from 'grpc-web-node-http-transport';
+import { NodeHttpTransport } from '@improbable-eng/grpc-web-node-http-transport';
 
 grpc.invoke(MyService.DoQuery, {
   host: "https://example.com",
@@ -18,7 +18,7 @@ grpc.invoke(MyService.DoQuery, {
 Alternatively specify the Default Transport when your server/application bootstraps:
 ```typescript
 import { grpc } from "@improbable-eng/grpc-web";
-import { NodeHttpTransport } from "grpc-web-node-http-transport";
+import { NodeHttpTransport } from "@improbable-eng/grpc-web-node-http-transport";
 
 // Do this first, before you make any grpc requests!
 grpc.setDefaultTransport(NodeHttpTransport());

--- a/client/grpc-web-node-http-transport/package-lock.json
+++ b/client/grpc-web-node-http-transport/package-lock.json
@@ -1,13 +1,34 @@
 {
-  "name": "grpc-web-node-http-transport",
-  "version": "0.0.1",
+  "name": "@improbable-eng/grpc-web-node-http-transport",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@improbable-eng/grpc-web": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.8.0.tgz",
+      "integrity": "sha512-0K9owV6BGGGVNkGXifsnMAE0Xoy675qqMdr8id4FOILbwxLk9HsJtZKz/zxfRXev1YY9JcAHm4vpZmbr6O+lyw==",
+      "dev": true,
+      "requires": {
+        "browser-headers": "^0.4.0"
+      }
+    },
     "@types/node": {
       "version": "10.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
       "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==",
+      "dev": true
+    },
+    "browser-headers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
+      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg==",
+      "dev": true
+    },
+    "google-protobuf": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.6.1.tgz",
+      "integrity": "sha512-SJYemeX5GjDLPnadcmCNQePQHCS4Hl5fOcI/JawqDIYFhCmrtYAjcx/oTQx/Wi8UuCuZQhfvftbmPePPAYHFtA==",
       "dev": true
     },
     "typescript": {

--- a/client/grpc-web-node-http-transport/package-lock.json
+++ b/client/grpc-web-node-http-transport/package-lock.json
@@ -4,25 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@improbable-eng/grpc-web": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.8.0.tgz",
-      "integrity": "sha512-0K9owV6BGGGVNkGXifsnMAE0Xoy675qqMdr8id4FOILbwxLk9HsJtZKz/zxfRXev1YY9JcAHm4vpZmbr6O+lyw==",
-      "dev": true,
-      "requires": {
-        "browser-headers": "^0.4.0"
-      }
-    },
     "@types/node": {
       "version": "10.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
       "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==",
-      "dev": true
-    },
-    "browser-headers": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
-      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg==",
       "dev": true
     },
     "google-protobuf": {

--- a/client/grpc-web-node-http-transport/package.json
+++ b/client/grpc-web-node-http-transport/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "grpc-web-node-http-transport",
-  "version": "0.0.1",
+  "name": "@improbable-eng/grpc-web-node-http-transport",
+  "version": "0.0.2",
   "description": "Node HTTP Transport for use with @improbable-eng/grpc-web",
   "main": "lib/index.js",
   "repository": {
@@ -13,13 +13,15 @@
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
-    "@improbable-eng/grpc-web": "^0.8.0"
-  },
   "author": "",
   "license": "Apache-2.0",
+  "peerDependencies": {
+    "@improbable-eng/grpc-web": ">=0.7.0"
+  },
   "devDependencies": {
+    "@improbable-eng/grpc-web": "^0.8.0",
     "@types/node": "^10.12.0",
+    "google-protobuf": "^3.2.0",
     "typescript": "^3.1.3"
   }
 }

--- a/client/grpc-web-node-http-transport/package.json
+++ b/client/grpc-web-node-http-transport/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
+  "author": "Improbable",
   "license": "Apache-2.0",
   "peerDependencies": {
     "@improbable-eng/grpc-web": ">=0.7.0"

--- a/client/grpc-web/package.json
+++ b/client/grpc-web/package.json
@@ -27,7 +27,6 @@
     "dist"
   ],
   "peerDependencies": {
-    "@types/google-protobuf": "^3.2.5",
     "google-protobuf": "^3.2.0"
   },
   "dependencies": {

--- a/integration_test/package.json
+++ b/integration_test/package.json
@@ -23,7 +23,7 @@
     "event-stream": "^3.3.4",
     "google-protobuf": "^3.2.0",
     "@improbable-eng/grpc-web": "^0.8.0",
-    "grpc-web-node-http-transport": "^0.0.1",
+    "@improbable-eng/grpc-web-node-http-transport": "^0.0.2",
     "typedarray": "0.0.6"
   },
   "devDependencies": {

--- a/integration_test/ts/src/testRpcCombinations.ts
+++ b/integration_test/ts/src/testRpcCombinations.ts
@@ -3,7 +3,7 @@ import {
   corsHost
 } from "../../hosts-config";
 import {grpc} from "@improbable-eng/grpc-web";
-import {NodeHttpTransport} from "grpc-web-node-http-transport";
+import {NodeHttpTransport} from "@improbable-eng/grpc-web-node-http-transport";
 
 type TestConfig = {
   testHostUrl: string,


### PR DESCRIPTION
To further disambiguate that this transport is specifically for use with the `@improbable-eng/grpc-web` package.

Note I've also fixed an issue with the dependencies; `@improbable-eng/grpc-web` should have been listed as a peer-dependency as it's intended to be used as a plugin (ie: the consumer is expected to have `@improbable-eng/grpc-web` somewhere in their dependency tree).