### PR TITLE
Fix: Eliminate x-grpc-web header

### DIFF
--- a/client/grpc-web/src/client.ts
+++ b/client/grpc-web/src/client.ts
@@ -262,7 +262,6 @@ class GrpcClient<TRequest extends ProtobufMessage, TResponse extends ProtobufMes
 
     const requestHeaders = new Metadata(metadata ? metadata : {});
     requestHeaders.set("content-type", "application/grpc-web+proto");
-    requestHeaders.set("x-grpc-web", "1"); // Required for CORS handling
 
     this.transport.start(requestHeaders);
   }

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -184,8 +184,7 @@ func (w *WrappedGrpcServer) IsGrpcWebRequest(req *http.Request) bool {
 //
 // You can control the CORS behaviour using `With*` options in the WrapServer function.
 func (w *WrappedGrpcServer) IsAcceptableGrpcCorsRequest(req *http.Request) bool {
-	accessControlHeaders := strings.ToLower(req.Header.Get("Access-Control-Request-Headers"))
-	if req.Method == http.MethodOptions && strings.Contains(accessControlHeaders, "x-grpc-web") {
+	if req.Method == http.MethodOptions && strings.HasPrefix(req.Header.Get("content-type"), grpcContentType) {
 		if w.opts.corsForRegisteredEndpointsOnly {
 			return w.isRequestForRegisteredEndpoint(req)
 		}


### PR DESCRIPTION
This changeset removes the custom `x-grpc-web` header, in favor of protocol-compliant content type sniffing on the server side. Fixes and closes improbable-eng/grpc-web#325.

So far, changes made:
- Modify Go server code to sniff for content type beginning with `application/grpc`
- Remove custom header from client code, so it is not sent

Curious for feedback from @johanbrandhost and @MarcusLongmuir. We don't use the Go server in production, we use Endpoints Service Proxy and Envoy.