### PR TITLE
Add Release Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,4 @@ jobs:
       script: ./lint-all.sh
     - stage: deploy
       if: tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      script: echo Releasing $TRAVIS_TAG
+      script: ./publish-all.sh "$TRAVIS_TAG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,8 @@ script:
 stages:
   - lint
   - test
-  - deploy
 
 jobs:
   include:
     - stage: lint
       script: ./lint-all.sh
-    - stage: deploy
-      if: tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      script: ./publish-all.sh "$TRAVIS_TAG"

--- a/go/generate-grpcwebproxy-binaries.sh
+++ b/go/generate-grpcwebproxy-binaries.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+rm -rf build
+mkdir -p build
+
+GOOS=linux GOARCH=amd64 go build -o build/grpcwebproxy-v0.8.1-linux-amd64 ./grpcwebproxy
+GOOS=windows GOARCH=amd64 go build -o build/grpcwebproxy-v0.8.1-windows-amd64.exe ./grpcwebproxy
+GOOS=darwin GOARCH=amd64 go build -o build/grpcwebproxy-v0.8.1-darwin-amd64 ./grpcwebproxy

--- a/go/generate-grpcwebproxy-binaries.sh
+++ b/go/generate-grpcwebproxy-binaries.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-rm -rf build
-mkdir -p build
-
-GOOS=linux GOARCH=amd64 go build -o build/grpcwebproxy-v0.8.1-linux-amd64 ./grpcwebproxy
-GOOS=windows GOARCH=amd64 go build -o build/grpcwebproxy-v0.8.1-windows-amd64.exe ./grpcwebproxy
-GOOS=darwin GOARCH=amd64 go build -o build/grpcwebproxy-v0.8.1-darwin-amd64 ./grpcwebproxy

--- a/lint-all.sh
+++ b/lint-all.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 echo "Linting go sources"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "@lerna/filter-options": "3.10.6",
         "@lerna/npm-conf": "3.7.0",
         "@lerna/validation-error": "3.6.0",
-        "dedent": "^0.7.0",
-        "libnpm": "^2.0.1",
-        "p-map": "^1.2.0",
-        "semver": "^5.5.0"
+        "dedent": "0.7.0",
+        "libnpm": "2.0.1",
+        "p-map": "1.2.0",
+        "semver": "5.6.0"
       }
     },
     "@lerna/batch-packages": {
@@ -28,7 +28,7 @@
       "requires": {
         "@lerna/package-graph": "3.10.6",
         "@lerna/validation-error": "3.6.0",
-        "libnpm": "^2.0.1"
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/bootstrap": {
@@ -50,16 +50,16 @@
         "@lerna/symlink-binary": "3.10.0",
         "@lerna/symlink-dependencies": "3.10.0",
         "@lerna/validation-error": "3.6.0",
-        "dedent": "^0.7.0",
-        "get-port": "^3.2.0",
-        "libnpm": "^2.0.1",
-        "multimatch": "^2.1.0",
-        "p-finally": "^1.0.0",
-        "p-map": "^1.2.0",
-        "p-map-series": "^1.0.0",
-        "p-waterfall": "^1.0.0",
-        "read-package-tree": "^5.1.6",
-        "semver": "^5.5.0"
+        "dedent": "0.7.0",
+        "get-port": "3.2.0",
+        "libnpm": "2.0.1",
+        "multimatch": "2.1.0",
+        "p-finally": "1.0.0",
+        "p-map": "1.2.0",
+        "p-map-series": "1.0.0",
+        "p-waterfall": "1.0.0",
+        "read-package-tree": "5.2.1",
+        "semver": "5.6.0"
       }
     },
     "@lerna/changed": {
@@ -91,9 +91,9 @@
       "integrity": "sha512-q2d/OPlNX/cBXB6Iz1932RFzOmOHq6ZzPjqebkINNaTojHWuuRpvJJY4Uz3NGpJ3kEtPDvBemkZqUBTSO5wb1g==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.1",
-        "execa": "^1.0.0",
-        "strong-log-transformer": "^2.0.0"
+        "chalk": "2.4.1",
+        "execa": "1.0.0",
+        "strong-log-transformer": "2.1.0"
       }
     },
     "@lerna/clean": {
@@ -107,9 +107,9 @@
         "@lerna/prompt": "3.6.0",
         "@lerna/pulse-till-done": "3.7.1",
         "@lerna/rimraf-dir": "3.10.0",
-        "p-map": "^1.2.0",
-        "p-map-series": "^1.0.0",
-        "p-waterfall": "^1.0.0"
+        "p-map": "1.2.0",
+        "p-map-series": "1.0.0",
+        "p-waterfall": "1.0.0"
       }
     },
     "@lerna/cli": {
@@ -119,9 +119,9 @@
       "dev": true,
       "requires": {
         "@lerna/global-options": "3.10.6",
-        "dedent": "^0.7.0",
-        "libnpm": "^2.0.1",
-        "yargs": "^12.0.1"
+        "dedent": "0.7.0",
+        "libnpm": "2.0.1",
+        "yargs": "12.0.5"
       }
     },
     "@lerna/collect-updates": {
@@ -132,9 +132,9 @@
       "requires": {
         "@lerna/child-process": "3.3.0",
         "@lerna/describe-ref": "3.10.0",
-        "libnpm": "^2.0.1",
-        "minimatch": "^3.0.4",
-        "slash": "^1.0.0"
+        "libnpm": "2.0.1",
+        "minimatch": "3.0.4",
+        "slash": "1.0.0"
       }
     },
     "@lerna/command": {
@@ -148,11 +148,11 @@
         "@lerna/project": "3.10.0",
         "@lerna/validation-error": "3.6.0",
         "@lerna/write-log-file": "3.6.0",
-        "dedent": "^0.7.0",
-        "execa": "^1.0.0",
-        "is-ci": "^1.0.10",
-        "libnpm": "^2.0.1",
-        "lodash": "^4.17.5"
+        "dedent": "0.7.0",
+        "execa": "1.0.0",
+        "is-ci": "1.2.1",
+        "libnpm": "2.0.1",
+        "lodash": "4.17.11"
       }
     },
     "@lerna/conventional-commits": {
@@ -162,13 +162,13 @@
       "dev": true,
       "requires": {
         "@lerna/validation-error": "3.6.0",
-        "conventional-changelog-angular": "^5.0.2",
-        "conventional-changelog-core": "^3.1.5",
-        "conventional-recommended-bump": "^4.0.4",
-        "fs-extra": "^7.0.0",
-        "get-stream": "^4.0.0",
-        "libnpm": "^2.0.1",
-        "semver": "^5.5.0"
+        "conventional-changelog-angular": "5.0.2",
+        "conventional-changelog-core": "3.1.5",
+        "conventional-recommended-bump": "4.0.4",
+        "fs-extra": "7.0.1",
+        "get-stream": "4.1.0",
+        "libnpm": "2.0.1",
+        "semver": "5.6.0"
       }
     },
     "@lerna/create": {
@@ -181,19 +181,19 @@
         "@lerna/command": "3.10.6",
         "@lerna/npm-conf": "3.7.0",
         "@lerna/validation-error": "3.6.0",
-        "camelcase": "^4.1.0",
-        "dedent": "^0.7.0",
-        "fs-extra": "^7.0.0",
-        "globby": "^8.0.1",
-        "init-package-json": "^1.10.3",
-        "libnpm": "^2.0.1",
-        "p-reduce": "^1.0.0",
-        "pify": "^3.0.0",
-        "semver": "^5.5.0",
-        "slash": "^1.0.0",
-        "validate-npm-package-license": "^3.0.3",
-        "validate-npm-package-name": "^3.0.0",
-        "whatwg-url": "^7.0.0"
+        "camelcase": "4.1.0",
+        "dedent": "0.7.0",
+        "fs-extra": "7.0.1",
+        "globby": "8.0.2",
+        "init-package-json": "1.10.3",
+        "libnpm": "2.0.1",
+        "p-reduce": "1.0.0",
+        "pify": "3.0.0",
+        "semver": "5.6.0",
+        "slash": "1.0.0",
+        "validate-npm-package-license": "3.0.4",
+        "validate-npm-package-name": "3.0.0",
+        "whatwg-url": "7.0.0"
       }
     },
     "@lerna/create-symlink": {
@@ -202,9 +202,9 @@
       "integrity": "sha512-YG3lTb6zylvmGqKU+QYA3ylSnoLn+FyLH5XZmUsD0i85R884+EyJJeHx/zUk+yrL2ZwHS4RBUgJfC24fqzgPoA==",
       "dev": true,
       "requires": {
-        "cmd-shim": "^2.0.2",
-        "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1"
+        "cmd-shim": "2.0.2",
+        "fs-extra": "7.0.1",
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/describe-ref": {
@@ -214,7 +214,7 @@
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.3.0",
-        "libnpm": "^2.0.1"
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/diff": {
@@ -226,7 +226,7 @@
         "@lerna/child-process": "3.3.0",
         "@lerna/command": "3.10.6",
         "@lerna/validation-error": "3.6.0",
-        "libnpm": "^2.0.1"
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/exec": {
@@ -251,7 +251,7 @@
       "requires": {
         "@lerna/collect-updates": "3.10.1",
         "@lerna/filter-packages": "3.10.0",
-        "dedent": "^0.7.0"
+        "dedent": "0.7.0"
       }
     },
     "@lerna/filter-packages": {
@@ -261,8 +261,8 @@
       "dev": true,
       "requires": {
         "@lerna/validation-error": "3.6.0",
-        "libnpm": "^2.0.1",
-        "multimatch": "^2.1.0"
+        "libnpm": "2.0.1",
+        "multimatch": "2.1.0"
       }
     },
     "@lerna/get-npm-exec-opts": {
@@ -271,7 +271,7 @@
       "integrity": "sha512-ruH6KuLlt75aCObXfUIdVJqmfVq7sgWGq5mXa05vc1MEqxTIiU23YiJdWzofQOOUOACaZkzZ4K4Nu7wXEg4Xgg==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1"
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/get-packed": {
@@ -280,9 +280,9 @@
       "integrity": "sha512-yuFtjsUZIHjeIvIYQ/QuytC+FQcHwo3peB+yGBST2uWCLUCR5rx6knoQcPzbxdFDCuUb5IFccFGd3B1fHFg3RQ==",
       "dev": true,
       "requires": {
-        "fs-extra": "^7.0.0",
-        "ssri": "^6.0.1",
-        "tar": "^4.4.8"
+        "fs-extra": "7.0.1",
+        "ssri": "6.0.1",
+        "tar": "4.4.8"
       },
       "dependencies": {
         "tar": {
@@ -291,13 +291,13 @@
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "yallist": {
@@ -321,7 +321,7 @@
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.3.0",
-        "semver": "^5.5.0"
+        "semver": "5.6.0"
       }
     },
     "@lerna/import": {
@@ -335,9 +335,9 @@
         "@lerna/prompt": "3.6.0",
         "@lerna/pulse-till-done": "3.7.1",
         "@lerna/validation-error": "3.6.0",
-        "dedent": "^0.7.0",
-        "fs-extra": "^7.0.0",
-        "p-map-series": "^1.0.0"
+        "dedent": "0.7.0",
+        "fs-extra": "7.0.1",
+        "p-map-series": "1.0.0"
       }
     },
     "@lerna/init": {
@@ -348,9 +348,9 @@
       "requires": {
         "@lerna/child-process": "3.3.0",
         "@lerna/command": "3.10.6",
-        "fs-extra": "^7.0.0",
-        "p-map": "^1.2.0",
-        "write-json-file": "^2.3.0"
+        "fs-extra": "7.0.1",
+        "p-map": "1.2.0",
+        "write-json-file": "2.3.0"
       }
     },
     "@lerna/link": {
@@ -362,8 +362,8 @@
         "@lerna/command": "3.10.6",
         "@lerna/package-graph": "3.10.6",
         "@lerna/symlink-dependencies": "3.10.0",
-        "p-map": "^1.2.0",
-        "slash": "^1.0.0"
+        "p-map": "1.2.0",
+        "slash": "1.0.0"
       }
     },
     "@lerna/list": {
@@ -385,8 +385,8 @@
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.10.6",
-        "chalk": "^2.3.1",
-        "columnify": "^1.5.4"
+        "chalk": "2.4.1",
+        "columnify": "1.5.4"
       }
     },
     "@lerna/log-packed": {
@@ -395,10 +395,10 @@
       "integrity": "sha512-T/J41zMkzpWB5nbiTRS5PmYTFn74mJXe6RQA2qhkdLi0UqnTp97Pux1loz3jsJf2yJtiQUnyMM7KuKIAge0Vlw==",
       "dev": true,
       "requires": {
-        "byte-size": "^4.0.3",
-        "columnify": "^1.5.4",
-        "has-unicode": "^2.0.1",
-        "libnpm": "^2.0.1"
+        "byte-size": "4.0.4",
+        "columnify": "1.5.4",
+        "has-unicode": "2.0.1",
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/npm-conf": {
@@ -407,8 +407,8 @@
       "integrity": "sha512-+WSMDfPKcKzMfqq283ydz9RRpOU6p9wfx0wy4hVSUY/6YUpsyuk8SShjcRtY8zTM5AOrxvFBuuV90H4YpZ5+Ng==",
       "dev": true,
       "requires": {
-        "config-chain": "^1.1.11",
-        "pify": "^3.0.0"
+        "config-chain": "1.1.12",
+        "pify": "3.0.0"
       }
     },
     "@lerna/npm-dist-tag": {
@@ -417,8 +417,8 @@
       "integrity": "sha512-VO57yKTB4NC2LZuTd4w0LmlRpoFm/gejQ1gqqLGzSJuSZaBXmieElFovzl21S07cqiy7FNVdz75x7/a6WCZ6XA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1",
-        "libnpm": "^2.0.1"
+        "figgy-pudding": "3.5.1",
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/npm-install": {
@@ -429,10 +429,10 @@
       "requires": {
         "@lerna/child-process": "3.3.0",
         "@lerna/get-npm-exec-opts": "3.6.0",
-        "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1",
-        "signal-exit": "^3.0.2",
-        "write-pkg": "^3.1.0"
+        "fs-extra": "7.0.1",
+        "libnpm": "2.0.1",
+        "signal-exit": "3.0.2",
+        "write-pkg": "3.2.0"
       }
     },
     "@lerna/npm-publish": {
@@ -442,9 +442,9 @@
       "dev": true,
       "requires": {
         "@lerna/run-lifecycle": "3.10.5",
-        "figgy-pudding": "^3.5.1",
-        "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1"
+        "figgy-pudding": "3.5.1",
+        "fs-extra": "7.0.1",
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/npm-run-script": {
@@ -455,7 +455,7 @@
       "requires": {
         "@lerna/child-process": "3.3.0",
         "@lerna/get-npm-exec-opts": "3.6.0",
-        "libnpm": "^2.0.1"
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/output": {
@@ -464,7 +464,7 @@
       "integrity": "sha512-9sjQouf6p7VQtVCRnzoTGlZyURd48i3ha3WBHC/UBJnHZFuXMqWVPKNuvnMf2kRXDyoQD+2mNywpmEJg5jOnRg==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1"
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/pack-directory": {
@@ -476,11 +476,11 @@
         "@lerna/get-packed": "3.7.0",
         "@lerna/package": "3.7.2",
         "@lerna/run-lifecycle": "3.10.5",
-        "figgy-pudding": "^3.5.1",
-        "libnpm": "^2.0.1",
-        "npm-packlist": "^1.1.12",
-        "tar": "^4.4.8",
-        "temp-write": "^3.4.0"
+        "figgy-pudding": "3.5.1",
+        "libnpm": "2.0.1",
+        "npm-packlist": "1.2.0",
+        "tar": "4.4.8",
+        "temp-write": "3.4.0"
       },
       "dependencies": {
         "tar": {
@@ -489,13 +489,13 @@
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "yallist": {
@@ -512,9 +512,9 @@
       "integrity": "sha512-8A5hN2CekM1a0Ix4VUO/g+REo+MsnXb8lnQ0bGjr1YGWzSL5NxYJ0Z9+0pwTfDpvRDYlFYO0rMVwBUW44b4dUw==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1",
-        "load-json-file": "^4.0.0",
-        "write-pkg": "^3.1.0"
+        "libnpm": "2.0.1",
+        "load-json-file": "4.0.0",
+        "write-pkg": "3.2.0"
       }
     },
     "@lerna/package-graph": {
@@ -524,8 +524,8 @@
       "dev": true,
       "requires": {
         "@lerna/validation-error": "3.6.0",
-        "libnpm": "^2.0.1",
-        "semver": "^5.5.0"
+        "libnpm": "2.0.1",
+        "semver": "5.6.0"
       }
     },
     "@lerna/project": {
@@ -536,16 +536,16 @@
       "requires": {
         "@lerna/package": "3.7.2",
         "@lerna/validation-error": "3.6.0",
-        "cosmiconfig": "^5.0.2",
-        "dedent": "^0.7.0",
-        "dot-prop": "^4.2.0",
-        "glob-parent": "^3.1.0",
-        "globby": "^8.0.1",
-        "libnpm": "^2.0.1",
-        "load-json-file": "^4.0.0",
-        "p-map": "^1.2.0",
-        "resolve-from": "^4.0.0",
-        "write-json-file": "^2.3.0"
+        "cosmiconfig": "5.0.7",
+        "dedent": "0.7.0",
+        "dot-prop": "4.2.0",
+        "glob-parent": "3.1.0",
+        "globby": "8.0.2",
+        "libnpm": "2.0.1",
+        "load-json-file": "4.0.0",
+        "p-map": "1.2.0",
+        "resolve-from": "4.0.0",
+        "write-json-file": "2.3.0"
       }
     },
     "@lerna/prompt": {
@@ -554,8 +554,8 @@
       "integrity": "sha512-nyAjPMolJ/ZRAAVcXrUH89C4n1SiWvLh4xWNvWYKLcf3PI5yges35sDFP/HYrM4+cEbkNFuJCRq6CxaET4PRsg==",
       "dev": true,
       "requires": {
-        "inquirer": "^6.2.0",
-        "libnpm": "^2.0.1"
+        "inquirer": "6.2.2",
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/publish": {
@@ -582,14 +582,14 @@
         "@lerna/run-parallel-batches": "3.0.0",
         "@lerna/validation-error": "3.6.0",
         "@lerna/version": "3.10.6",
-        "figgy-pudding": "^3.5.1",
-        "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1",
-        "p-finally": "^1.0.0",
-        "p-map": "^1.2.0",
-        "p-pipe": "^1.2.0",
-        "p-reduce": "^1.0.0",
-        "semver": "^5.5.0"
+        "figgy-pudding": "3.5.1",
+        "fs-extra": "7.0.1",
+        "libnpm": "2.0.1",
+        "p-finally": "1.0.0",
+        "p-map": "1.2.0",
+        "p-pipe": "1.2.0",
+        "p-reduce": "1.0.0",
+        "semver": "5.6.0"
       }
     },
     "@lerna/pulse-till-done": {
@@ -598,7 +598,7 @@
       "integrity": "sha512-MzpesZeW3Mc+CiAq4zUt9qTXI9uEBBKrubYHE36voQTSkHvu/Rox6YOvfUr+U7P6k8frFPeCgGpfMDTLhiqe6w==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1"
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/resolve-symlink": {
@@ -607,9 +607,9 @@
       "integrity": "sha512-TVOAEqHJSQVhNDMFCwEUZPaOETqHDQV1TQWQfC8ZlOqyaUQ7veZUbg0yfG7RPNzlSpvF0ZaGFeR0YhYDAW03GA==",
       "dev": true,
       "requires": {
-        "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1",
-        "read-cmd-shim": "^1.0.1"
+        "fs-extra": "7.0.1",
+        "libnpm": "2.0.1",
+        "read-cmd-shim": "1.0.1"
       }
     },
     "@lerna/rimraf-dir": {
@@ -619,9 +619,9 @@
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.3.0",
-        "libnpm": "^2.0.1",
-        "path-exists": "^3.0.0",
-        "rimraf": "^2.6.2"
+        "libnpm": "2.0.1",
+        "path-exists": "3.0.0",
+        "rimraf": "2.6.3"
       }
     },
     "@lerna/run": {
@@ -638,7 +638,7 @@
         "@lerna/run-parallel-batches": "3.0.0",
         "@lerna/timer": "3.5.0",
         "@lerna/validation-error": "3.6.0",
-        "p-map": "^1.2.0"
+        "p-map": "1.2.0"
       }
     },
     "@lerna/run-lifecycle": {
@@ -648,8 +648,8 @@
       "dev": true,
       "requires": {
         "@lerna/npm-conf": "3.7.0",
-        "figgy-pudding": "^3.5.1",
-        "libnpm": "^2.0.1"
+        "figgy-pudding": "3.5.1",
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/run-parallel-batches": {
@@ -658,8 +658,8 @@
       "integrity": "sha512-Mj1ravlXF7AkkewKd9YFq9BtVrsStNrvVLedD/b2wIVbNqcxp8lS68vehXVOzoL/VWNEDotvqCQtyDBilCodGw==",
       "dev": true,
       "requires": {
-        "p-map": "^1.2.0",
-        "p-map-series": "^1.0.0"
+        "p-map": "1.2.0",
+        "p-map-series": "1.0.0"
       }
     },
     "@lerna/symlink-binary": {
@@ -670,8 +670,8 @@
       "requires": {
         "@lerna/create-symlink": "3.6.0",
         "@lerna/package": "3.7.2",
-        "fs-extra": "^7.0.0",
-        "p-map": "^1.2.0"
+        "fs-extra": "7.0.1",
+        "p-map": "1.2.0"
       }
     },
     "@lerna/symlink-dependencies": {
@@ -683,10 +683,10 @@
         "@lerna/create-symlink": "3.6.0",
         "@lerna/resolve-symlink": "3.6.0",
         "@lerna/symlink-binary": "3.10.0",
-        "fs-extra": "^7.0.0",
-        "p-finally": "^1.0.0",
-        "p-map": "^1.2.0",
-        "p-map-series": "^1.0.0"
+        "fs-extra": "7.0.1",
+        "p-finally": "1.0.0",
+        "p-map": "1.2.0",
+        "p-map-series": "1.0.0"
       }
     },
     "@lerna/timer": {
@@ -701,7 +701,7 @@
       "integrity": "sha512-MWltncGO5VgMS0QedTlZCjFUMF/evRjDMMHrtVorkIB2Cp5xy0rkKa8iDBG43qpUWeG1giwi58yUlETBcWfILw==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1"
+        "libnpm": "2.0.1"
       }
     },
     "@lerna/version": {
@@ -720,17 +720,17 @@
         "@lerna/prompt": "3.6.0",
         "@lerna/run-lifecycle": "3.10.5",
         "@lerna/validation-error": "3.6.0",
-        "chalk": "^2.3.1",
-        "dedent": "^0.7.0",
-        "libnpm": "^2.0.1",
-        "minimatch": "^3.0.4",
-        "p-map": "^1.2.0",
-        "p-pipe": "^1.2.0",
-        "p-reduce": "^1.0.0",
-        "p-waterfall": "^1.0.0",
-        "semver": "^5.5.0",
-        "slash": "^1.0.0",
-        "temp-write": "^3.4.0"
+        "chalk": "2.4.1",
+        "dedent": "0.7.0",
+        "libnpm": "2.0.1",
+        "minimatch": "3.0.4",
+        "p-map": "1.2.0",
+        "p-pipe": "1.2.0",
+        "p-reduce": "1.0.0",
+        "p-waterfall": "1.0.0",
+        "semver": "5.6.0",
+        "slash": "1.0.0",
+        "temp-write": "3.4.0"
       }
     },
     "@lerna/write-log-file": {
@@ -739,8 +739,8 @@
       "integrity": "sha512-OkLK99V6sYXsJsYg+O9wtiFS3z6eUPaiz2e6cXJt80mfIIdI1t2dnmyua0Ib5cZWExQvx2z6Y32Wlf0MnsoNsA==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1",
-        "write-file-atomic": "^2.3.0"
+        "libnpm": "2.0.1",
+        "write-file-atomic": "2.4.2"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -749,8 +749,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -759,14 +759,55 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@octokit/endpoint": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.2.tgz",
+      "integrity": "sha512-iRx4kDYybAv9tOrHDBE6HwlgiFi8qmbZl8SHliZWtxbUFuXLZXh2yv8DxGIK9wzD9J0wLDMZneO8vNYJNUSJ9Q==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "3.1.0",
+        "is-plain-object": "2.0.4",
+        "universal-user-agent": "2.0.3",
+        "url-template": "2.0.8"
+      }
+    },
+    "@octokit/request": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.3.0.tgz",
+      "integrity": "sha512-5YRqYNZOAaL7+nt7w3Scp6Sz4P2g7wKFP9npx1xdExMomk8/M/ICXVLYVam2wzxeY0cIc6wcKpjC5KI4jiNbGw==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "3.1.2",
+        "is-plain-object": "2.0.4",
+        "node-fetch": "2.3.0",
+        "universal-user-agent": "2.0.3"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.15.0.tgz",
+      "integrity": "sha512-Un+e7rgh38RtPOTe453pT/KPM/p2KZICimBmuZCd2wEo8PacDa4h6RqTPZs+f2DPazTTqdM7QU4LKlUjgiBwWw==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "2.3.0",
+        "before-after-hook": "1.3.2",
+        "btoa-lite": "1.0.0",
+        "lodash.get": "4.4.2",
+        "lodash.set": "4.3.2",
+        "lodash.uniq": "4.5.0",
+        "octokit-pagination-methods": "1.1.0",
+        "universal-user-agent": "2.0.3",
+        "url-template": "2.0.8"
+      }
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "abbrev": {
@@ -781,7 +822,7 @@
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "es6-promisify": "5.0.0"
       }
     },
     "agentkeepalive": {
@@ -790,7 +831,7 @@
       "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
       "dev": true,
       "requires": {
-        "humanize-ms": "^1.2.1"
+        "humanize-ms": "1.2.1"
       }
     },
     "ajv": {
@@ -799,10 +840,10 @@
       "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ansi-escapes": {
@@ -823,7 +864,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "aproba": {
@@ -838,8 +879,8 @@
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -848,7 +889,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -893,7 +934,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -926,7 +967,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -947,7 +988,7 @@
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "asynckit": {
@@ -980,9 +1021,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -993,15 +1034,15 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -1010,6 +1051,16 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.6.4",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "balanced-match": {
@@ -1024,13 +1075,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1039,7 +1090,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1048,7 +1099,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1057,7 +1108,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1066,9 +1117,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1079,8 +1130,14 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
+    },
+    "before-after-hook": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz",
+      "integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w==",
+      "dev": true
     },
     "bin-links": {
       "version": "1.1.2",
@@ -1088,11 +1145,11 @@
       "integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.0",
-        "cmd-shim": "^2.0.2",
-        "gentle-fs": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "write-file-atomic": "^2.3.0"
+        "bluebird": "3.5.3",
+        "cmd-shim": "2.0.2",
+        "gentle-fs": "2.0.1",
+        "graceful-fs": "4.1.15",
+        "write-file-atomic": "2.4.2"
       }
     },
     "block-stream": {
@@ -1101,7 +1158,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "bluebird": {
@@ -1116,7 +1173,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1126,16 +1183,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1144,10 +1201,16 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1185,20 +1248,20 @@
       "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.3",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.15",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
+        "bluebird": "3.5.3",
+        "chownr": "1.1.1",
+        "figgy-pudding": "3.5.1",
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.15",
+        "lru-cache": "5.1.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.3",
+        "ssri": "6.0.1",
+        "unique-filename": "1.1.1",
+        "y18n": "4.0.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -1207,7 +1270,7 @@
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
+            "yallist": "3.0.3"
           }
         },
         "yallist": {
@@ -1224,15 +1287,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "call-me-maybe": {
@@ -1247,7 +1310,7 @@
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
-        "callsites": "^2.0.0"
+        "callsites": "2.0.0"
       }
     },
     "caller-path": {
@@ -1256,7 +1319,7 @@
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
-        "caller-callsite": "^2.0.0"
+        "caller-callsite": "2.0.0"
       }
     },
     "callsites": {
@@ -1277,9 +1340,9 @@
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0",
-        "map-obj": "^2.0.0",
-        "quick-lru": "^1.0.0"
+        "camelcase": "4.1.0",
+        "map-obj": "2.0.0",
+        "quick-lru": "1.1.0"
       }
     },
     "caseless": {
@@ -1294,9 +1357,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "chardet": {
@@ -1323,10 +1386,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -1335,7 +1398,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -1346,7 +1409,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -1361,9 +1424,9 @@
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1384,8 +1447,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -1394,7 +1457,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1411,8 +1474,8 @@
       "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "~0.5.0"
+        "graceful-fs": "4.1.15",
+        "mkdirp": "0.5.1"
       }
     },
     "code-point-at": {
@@ -1427,8 +1490,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -1452,8 +1515,8 @@
       "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "requires": {
-        "strip-ansi": "^3.0.0",
-        "wcwidth": "^1.0.0"
+        "strip-ansi": "3.0.1",
+        "wcwidth": "1.0.1"
       }
     },
     "combined-stream": {
@@ -1462,7 +1525,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -1477,8 +1540,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
+        "array-ify": "1.0.0",
+        "dot-prop": "3.0.0"
       },
       "dependencies": {
         "dot-prop": {
@@ -1487,7 +1550,7 @@
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
           "dev": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "1.0.1"
           }
         }
       }
@@ -1510,10 +1573,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "config-chain": {
@@ -1522,8 +1585,8 @@
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
       }
     },
     "console-control-strings": {
@@ -1538,8 +1601,8 @@
       "integrity": "sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-core": {
@@ -1548,19 +1611,19 @@
       "integrity": "sha512-iwqAotS4zk0wA4S84YY1JCUG7X3LxaRjJxuUo6GI4dZuIy243j5nOg/Ora35ExT4DOiw5dQbMMQvw2SUjh6moQ==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "^4.0.2",
-        "conventional-commits-parser": "^3.0.1",
-        "dateformat": "^3.0.0",
-        "get-pkg-repo": "^1.0.0",
+        "conventional-changelog-writer": "4.0.2",
+        "conventional-commits-parser": "3.0.1",
+        "dateformat": "3.0.3",
+        "get-pkg-repo": "1.4.0",
         "git-raw-commits": "2.0.0",
-        "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^2.0.2",
-        "lodash": "^4.2.1",
-        "normalize-package-data": "^2.3.5",
-        "q": "^1.5.1",
-        "read-pkg": "^3.0.0",
-        "read-pkg-up": "^3.0.0",
-        "through2": "^2.0.0"
+        "git-remote-origin-url": "2.0.0",
+        "git-semver-tags": "2.0.2",
+        "lodash": "4.17.11",
+        "normalize-package-data": "2.4.2",
+        "q": "1.5.1",
+        "read-pkg": "3.0.0",
+        "read-pkg-up": "3.0.0",
+        "through2": "2.0.5"
       }
     },
     "conventional-changelog-preset-loader": {
@@ -1575,16 +1638,16 @@
       "integrity": "sha512-d8/FQY/fix2xXEBUhOo8u3DCbyEw3UOQgYHxLsPDw+wHUDma/GQGAGsGtoH876WyNs32fViHmTOUrgRKVLvBug==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^2.0.1",
-        "dateformat": "^3.0.0",
-        "handlebars": "^4.0.2",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "semver": "^5.5.0",
-        "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "compare-func": "1.3.2",
+        "conventional-commits-filter": "2.0.1",
+        "dateformat": "3.0.3",
+        "handlebars": "4.0.12",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.11",
+        "meow": "4.0.1",
+        "semver": "5.6.0",
+        "split": "1.0.1",
+        "through2": "2.0.5"
       }
     },
     "conventional-commits-filter": {
@@ -1593,8 +1656,8 @@
       "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
-        "modify-values": "^1.0.0"
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.1"
       }
     },
     "conventional-commits-parser": {
@@ -1603,13 +1666,13 @@
       "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
-        "is-text-path": "^1.0.0",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "JSONStream": "1.3.5",
+        "is-text-path": "1.0.1",
+        "lodash": "4.17.11",
+        "meow": "4.0.1",
+        "split2": "2.2.0",
+        "through2": "2.0.5",
+        "trim-off-newlines": "1.0.1"
       }
     },
     "conventional-recommended-bump": {
@@ -1618,14 +1681,14 @@
       "integrity": "sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.6.0",
-        "conventional-changelog-preset-loader": "^2.0.2",
-        "conventional-commits-filter": "^2.0.1",
-        "conventional-commits-parser": "^3.0.1",
+        "concat-stream": "1.6.2",
+        "conventional-changelog-preset-loader": "2.0.2",
+        "conventional-commits-filter": "2.0.1",
+        "conventional-commits-parser": "3.0.1",
         "git-raw-commits": "2.0.0",
-        "git-semver-tags": "^2.0.2",
-        "meow": "^4.0.0",
-        "q": "^1.5.1"
+        "git-semver-tags": "2.0.2",
+        "meow": "4.0.1",
+        "q": "1.5.1"
       }
     },
     "copy-concurrently": {
@@ -1634,18 +1697,24 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.3",
+        "run-queue": "1.0.3"
       }
     },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+      "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
       "dev": true
     },
     "core-util-is": {
@@ -1660,10 +1729,10 @@
       "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
       "dev": true,
       "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0"
+        "import-fresh": "2.0.0",
+        "is-directory": "0.3.1",
+        "js-yaml": "3.12.0",
+        "parse-json": "4.0.0"
       }
     },
     "cross-spawn": {
@@ -1672,11 +1741,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.6.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "currently-unhandled": {
@@ -1685,7 +1754,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "cyclist": {
@@ -1700,7 +1769,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "dashdash": {
@@ -1709,7 +1778,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "dateformat": {
@@ -1753,8 +1822,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "map-obj": {
@@ -1777,13 +1846,19 @@
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.1.0.tgz",
+      "integrity": "sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg==",
+      "dev": true
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.4"
       }
     },
     "define-property": {
@@ -1792,8 +1867,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1802,7 +1877,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1811,7 +1886,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1820,9 +1895,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1851,8 +1926,8 @@
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
+        "asap": "2.0.6",
+        "wrappy": "1.0.2"
       }
     },
     "diff": {
@@ -1867,8 +1942,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       }
     },
     "dot-prop": {
@@ -1877,7 +1952,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "duplexer": {
@@ -1892,10 +1967,10 @@
       "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -1904,8 +1979,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "encoding": {
@@ -1914,7 +1989,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.24"
       }
     },
     "end-of-stream": {
@@ -1923,7 +1998,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "err-code": {
@@ -1938,7 +2013,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es6-promise": {
@@ -1949,11 +2024,11 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.2.5"
       }
     },
     "escape-string-regexp": {
@@ -1980,13 +2055,13 @@
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "4.1.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-brackets": {
@@ -1995,13 +2070,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -2019,7 +2094,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -2028,7 +2103,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -2051,8 +2126,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2061,7 +2136,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -2072,9 +2147,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -2083,14 +2158,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -2099,7 +2174,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -2108,7 +2183,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -2117,7 +2192,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2126,7 +2201,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2135,9 +2210,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -2160,12 +2235,12 @@
       "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.3",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.3",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "is-glob": {
@@ -2197,7 +2272,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "fill-range": {
@@ -2206,10 +2281,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2218,7 +2293,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2235,7 +2310,7 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "flush-write-stream": {
@@ -2244,8 +2319,8 @@
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "for-in": {
@@ -2266,9 +2341,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
       }
     },
     "fragment-cache": {
@@ -2277,7 +2352,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "from2": {
@@ -2286,8 +2361,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "fs-extra": {
@@ -2296,9 +2371,9 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.15",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       }
     },
     "fs-minipass": {
@@ -2307,7 +2382,7 @@
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "dev": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.5"
       }
     },
     "fs-vacuum": {
@@ -2316,9 +2391,9 @@
       "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "path-is-inside": "^1.0.1",
-        "rimraf": "^2.5.2"
+        "graceful-fs": "4.1.15",
+        "path-is-inside": "1.0.2",
+        "rimraf": "2.6.3"
       }
     },
     "fs-write-stream-atomic": {
@@ -2327,10 +2402,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
+        "graceful-fs": "4.1.15",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.6"
       }
     },
     "fs.realpath": {
@@ -2345,10 +2420,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.15",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.3"
       }
     },
     "gauge": {
@@ -2357,14 +2432,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
       }
     },
     "genfun": {
@@ -2379,14 +2454,14 @@
       "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.2",
-        "fs-vacuum": "^1.2.10",
-        "graceful-fs": "^4.1.11",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "path-is-inside": "^1.0.2",
-        "read-cmd-shim": "^1.0.1",
-        "slide": "^1.1.6"
+        "aproba": "1.2.0",
+        "fs-vacuum": "1.2.10",
+        "graceful-fs": "4.1.15",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "path-is-inside": "1.0.2",
+        "read-cmd-shim": "1.0.1",
+        "slide": "1.1.6"
       }
     },
     "get-caller-file": {
@@ -2401,11 +2476,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "meow": "^3.3.0",
-        "normalize-package-data": "^2.3.0",
-        "parse-github-repo-url": "^1.3.0",
-        "through2": "^2.0.0"
+        "hosted-git-info": "2.7.1",
+        "meow": "3.7.0",
+        "normalize-package-data": "2.4.2",
+        "parse-github-repo-url": "1.4.1",
+        "through2": "2.0.5"
       },
       "dependencies": {
         "camelcase": {
@@ -2416,12 +2491,12 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "find-up": {
@@ -2430,8 +2505,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "indent-string": {
@@ -2440,7 +2515,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "load-json-file": {
@@ -2449,11 +2524,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.15",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "map-obj": {
@@ -2464,20 +2539,20 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.2",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "minimist": {
@@ -2492,7 +2567,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         },
         "path-exists": {
@@ -2501,7 +2576,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -2510,9 +2585,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.15",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -2527,9 +2602,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.2",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -2538,8 +2613,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "redent": {
@@ -2548,8 +2623,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "strip-bom": {
@@ -2558,7 +2633,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-indent": {
@@ -2567,7 +2642,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -2596,7 +2671,7 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
-        "pump": "^3.0.0"
+        "pump": "3.0.0"
       }
     },
     "get-value": {
@@ -2611,7 +2686,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "git-raw-commits": {
@@ -2620,11 +2695,11 @@
       "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
       "dev": true,
       "requires": {
-        "dargs": "^4.0.1",
-        "lodash.template": "^4.0.2",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0"
+        "dargs": "4.1.0",
+        "lodash.template": "4.4.0",
+        "meow": "4.0.1",
+        "split2": "2.2.0",
+        "through2": "2.0.5"
       }
     },
     "git-remote-origin-url": {
@@ -2633,13 +2708,13 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "^1.0.0",
-        "pify": "^2.3.0"
+        "gitconfiglocal": "1.0.0",
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -2651,8 +2726,8 @@
       "integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
       "dev": true,
       "requires": {
-        "meow": "^4.0.0",
-        "semver": "^5.5.0"
+        "meow": "4.0.1",
+        "semver": "5.6.0"
       }
     },
     "gitconfiglocal": {
@@ -2661,7 +2736,30 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.2"
+        "ini": "1.3.5"
+      }
+    },
+    "github-release-cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/github-release-cli/-/github-release-cli-1.0.1.tgz",
+      "integrity": "sha512-DYsXH773l28fFAer9qxhjfWM6QDAufjt7Inn34IkRQlCzZ4091IZT+V8etL3yq/SOD1jy/BsFJTXdXcYdVoAUg==",
+      "dev": true,
+      "requires": {
+        "@octokit/rest": "16.15.0",
+        "babel-runtime": "6.26.0",
+        "commander": "2.19.0",
+        "http-link-header": "1.0.2",
+        "mime-types": "2.1.21",
+        "minimatch": "3.0.4",
+        "url-parse": "1.4.4"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
+        }
       }
     },
     "glob": {
@@ -2670,12 +2768,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-parent": {
@@ -2684,8 +2782,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       }
     },
     "glob-to-regexp": {
@@ -2700,13 +2798,13 @@
       "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
+        "array-union": "1.0.2",
         "dir-glob": "2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "fast-glob": "2.2.6",
+        "glob": "7.1.3",
+        "ignore": "3.3.10",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -2721,10 +2819,10 @@
       "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "async": "2.6.1",
+        "optimist": "0.6.1",
+        "source-map": "0.6.1",
+        "uglify-js": "3.4.9"
       },
       "dependencies": {
         "source-map": {
@@ -2747,8 +2845,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.7.0",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -2757,7 +2855,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -2778,9 +2876,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -2789,8 +2887,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2799,7 +2897,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -2816,13 +2914,19 @@
       "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
       "dev": true
     },
+    "http-link-header": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.2.tgz",
+      "integrity": "sha512-z6YOZ8ZEnejkcCWlGZzYXNa6i+ZaTfiTg3WhlV/YvnNya3W/RbX1bMVUMTuCrg/DrtTCQxaFCkXCz4FtLpcebg==",
+      "dev": true
+    },
     "http-proxy-agent": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "agent-base": "4",
+        "agent-base": "4.2.1",
         "debug": "3.1.0"
       }
     },
@@ -2832,9 +2936,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
       }
     },
     "https-proxy-agent": {
@@ -2843,8 +2947,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
       }
     },
     "humanize-ms": {
@@ -2853,7 +2957,7 @@
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
-        "ms": "^2.0.0"
+        "ms": "2.1.1"
       }
     },
     "iconv-lite": {
@@ -2862,7 +2966,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "iferr": {
@@ -2883,7 +2987,7 @@
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "3.0.4"
       }
     },
     "import-fresh": {
@@ -2892,8 +2996,8 @@
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "caller-path": "2.0.0",
+        "resolve-from": "3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -2910,8 +3014,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -2932,8 +3036,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -2954,14 +3058,14 @@
       "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.1",
-        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-        "promzard": "^0.3.0",
-        "read": "~1.0.1",
-        "read-package-json": "1 || 2",
-        "semver": "2.x || 3.x || 4 || 5",
-        "validate-npm-package-license": "^3.0.1",
-        "validate-npm-package-name": "^3.0.0"
+        "glob": "7.1.3",
+        "npm-package-arg": "6.1.0",
+        "promzard": "0.3.0",
+        "read": "1.0.7",
+        "read-package-json": "2.0.13",
+        "semver": "5.6.0",
+        "validate-npm-package-license": "3.0.4",
+        "validate-npm-package-name": "3.0.0"
       }
     },
     "inquirer": {
@@ -2970,19 +3074,19 @@
       "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.0.3",
+        "figures": "2.0.0",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "6.4.0",
+        "string-width": "2.1.1",
+        "strip-ansi": "5.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2997,9 +3101,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -3035,7 +3139,7 @@
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -3066,7 +3170,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3075,7 +3179,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3094,11 +3198,11 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
@@ -3107,7 +3211,7 @@
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.5.0"
+        "ci-info": "1.6.0"
       }
     },
     "is-data-descriptor": {
@@ -3116,7 +3220,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3125,7 +3229,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3136,9 +3240,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3173,7 +3277,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -3182,7 +3286,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -3191,7 +3295,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-number": {
@@ -3200,7 +3304,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3209,7 +3313,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3232,7 +3336,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-promise": {
@@ -3259,7 +3363,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "^1.0.0"
+        "text-extensions": "1.9.0"
       }
     },
     "is-typedarray": {
@@ -3316,8 +3420,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -3356,7 +3460,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.15"
       }
     },
     "jsonparse": {
@@ -3389,7 +3493,7 @@
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "^2.0.0"
+        "invert-kv": "2.0.0"
       }
     },
     "lerna": {
@@ -3413,8 +3517,8 @@
         "@lerna/publish": "3.10.7",
         "@lerna/run": "3.10.6",
         "@lerna/version": "3.10.6",
-        "import-local": "^1.0.0",
-        "libnpm": "^2.0.1"
+        "import-local": "1.0.0",
+        "libnpm": "2.0.1"
       }
     },
     "libnpm": {
@@ -3423,26 +3527,26 @@
       "integrity": "sha512-qTKoxyJvpBxHZQB6k0AhSLajyXq9ZE/lUsZzuHAplr2Bpv9G+k4YuYlExYdUCeVRRGqcJt8hvkPh4tBwKoV98w==",
       "dev": true,
       "requires": {
-        "bin-links": "^1.1.2",
-        "bluebird": "^3.5.3",
-        "find-npm-prefix": "^1.0.2",
-        "libnpmaccess": "^3.0.1",
-        "libnpmconfig": "^1.2.1",
-        "libnpmhook": "^5.0.2",
-        "libnpmorg": "^1.0.0",
-        "libnpmpublish": "^1.1.0",
-        "libnpmsearch": "^2.0.0",
-        "libnpmteam": "^1.0.1",
-        "lock-verify": "^2.0.2",
-        "npm-lifecycle": "^2.1.0",
-        "npm-logical-tree": "^1.2.1",
-        "npm-package-arg": "^6.1.0",
-        "npm-profile": "^4.0.1",
-        "npm-registry-fetch": "^3.8.0",
-        "npmlog": "^4.1.2",
-        "pacote": "^9.2.3",
-        "read-package-json": "^2.0.13",
-        "stringify-package": "^1.0.0"
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.3",
+        "find-npm-prefix": "1.0.2",
+        "libnpmaccess": "3.0.1",
+        "libnpmconfig": "1.2.1",
+        "libnpmhook": "5.0.2",
+        "libnpmorg": "1.0.0",
+        "libnpmpublish": "1.1.1",
+        "libnpmsearch": "2.0.0",
+        "libnpmteam": "1.0.1",
+        "lock-verify": "2.0.2",
+        "npm-lifecycle": "2.1.0",
+        "npm-logical-tree": "1.2.1",
+        "npm-package-arg": "6.1.0",
+        "npm-profile": "4.0.1",
+        "npm-registry-fetch": "3.9.0",
+        "npmlog": "4.1.2",
+        "pacote": "9.4.1",
+        "read-package-json": "2.0.13",
+        "stringify-package": "1.0.0"
       }
     },
     "libnpmaccess": {
@@ -3451,10 +3555,10 @@
       "integrity": "sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==",
       "dev": true,
       "requires": {
-        "aproba": "^2.0.0",
-        "get-stream": "^4.0.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-registry-fetch": "^3.8.0"
+        "aproba": "2.0.0",
+        "get-stream": "4.1.0",
+        "npm-package-arg": "6.1.0",
+        "npm-registry-fetch": "3.9.0"
       },
       "dependencies": {
         "aproba": {
@@ -3471,9 +3575,9 @@
       "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1",
-        "find-up": "^3.0.0",
-        "ini": "^1.3.5"
+        "figgy-pudding": "3.5.1",
+        "find-up": "3.0.0",
+        "ini": "1.3.5"
       }
     },
     "libnpmhook": {
@@ -3482,10 +3586,10 @@
       "integrity": "sha512-vLenmdFWhRfnnZiNFPNMog6CK7Ujofy2TWiM2CrpZUjBRIhHkJeDaAbJdYCT6W4lcHtyrJR8yXW8KFyq6UAp1g==",
       "dev": true,
       "requires": {
-        "aproba": "^2.0.0",
-        "figgy-pudding": "^3.4.1",
-        "get-stream": "^4.0.0",
-        "npm-registry-fetch": "^3.8.0"
+        "aproba": "2.0.0",
+        "figgy-pudding": "3.5.1",
+        "get-stream": "4.1.0",
+        "npm-registry-fetch": "3.9.0"
       },
       "dependencies": {
         "aproba": {
@@ -3502,10 +3606,10 @@
       "integrity": "sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==",
       "dev": true,
       "requires": {
-        "aproba": "^2.0.0",
-        "figgy-pudding": "^3.4.1",
-        "get-stream": "^4.0.0",
-        "npm-registry-fetch": "^3.8.0"
+        "aproba": "2.0.0",
+        "figgy-pudding": "3.5.1",
+        "get-stream": "4.1.0",
+        "npm-registry-fetch": "3.9.0"
       },
       "dependencies": {
         "aproba": {
@@ -3522,15 +3626,15 @@
       "integrity": "sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==",
       "dev": true,
       "requires": {
-        "aproba": "^2.0.0",
-        "figgy-pudding": "^3.5.1",
-        "get-stream": "^4.0.0",
-        "lodash.clonedeep": "^4.5.0",
-        "normalize-package-data": "^2.4.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-registry-fetch": "^3.8.0",
-        "semver": "^5.5.1",
-        "ssri": "^6.0.1"
+        "aproba": "2.0.0",
+        "figgy-pudding": "3.5.1",
+        "get-stream": "4.1.0",
+        "lodash.clonedeep": "4.5.0",
+        "normalize-package-data": "2.4.2",
+        "npm-package-arg": "6.1.0",
+        "npm-registry-fetch": "3.9.0",
+        "semver": "5.6.0",
+        "ssri": "6.0.1"
       },
       "dependencies": {
         "aproba": {
@@ -3547,9 +3651,9 @@
       "integrity": "sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1",
-        "get-stream": "^4.0.0",
-        "npm-registry-fetch": "^3.8.0"
+        "figgy-pudding": "3.5.1",
+        "get-stream": "4.1.0",
+        "npm-registry-fetch": "3.9.0"
       }
     },
     "libnpmteam": {
@@ -3558,10 +3662,10 @@
       "integrity": "sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==",
       "dev": true,
       "requires": {
-        "aproba": "^2.0.0",
-        "figgy-pudding": "^3.4.1",
-        "get-stream": "^4.0.0",
-        "npm-registry-fetch": "^3.8.0"
+        "aproba": "2.0.0",
+        "figgy-pudding": "3.5.1",
+        "get-stream": "4.1.0",
+        "npm-registry-fetch": "3.9.0"
       },
       "dependencies": {
         "aproba": {
@@ -3578,10 +3682,10 @@
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.15",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -3590,8 +3694,8 @@
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lock-verify": {
@@ -3600,8 +3704,8 @@
       "integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
       "dev": true,
       "requires": {
-        "npm-package-arg": "^5.1.2 || 6",
-        "semver": "^5.4.1"
+        "npm-package-arg": "6.1.0",
+        "semver": "5.6.0"
       }
     },
     "lodash": {
@@ -3622,6 +3726,18 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -3634,8 +3750,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -3644,8 +3760,14 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -3653,8 +3775,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lru-cache": {
@@ -3663,9 +3785,15 @@
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
+    },
+    "macos-release": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
+      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==",
+      "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
@@ -3673,7 +3801,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-fetch-happen": {
@@ -3682,17 +3810,17 @@
       "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
       "dev": true,
       "requires": {
-        "agentkeepalive": "^3.4.1",
-        "cacache": "^11.0.1",
-        "http-cache-semantics": "^3.8.1",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
-        "lru-cache": "^4.1.2",
-        "mississippi": "^3.0.0",
-        "node-fetch-npm": "^2.0.2",
-        "promise-retry": "^1.1.1",
-        "socks-proxy-agent": "^4.0.0",
-        "ssri": "^6.0.0"
+        "agentkeepalive": "3.5.2",
+        "cacache": "11.3.2",
+        "http-cache-semantics": "3.8.1",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1",
+        "lru-cache": "4.1.5",
+        "mississippi": "3.0.0",
+        "node-fetch-npm": "2.0.2",
+        "promise-retry": "1.1.1",
+        "socks-proxy-agent": "4.0.1",
+        "ssri": "6.0.1"
       }
     },
     "map-age-cleaner": {
@@ -3701,7 +3829,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "^1.0.0"
+        "p-defer": "1.0.0"
       }
     },
     "map-cache": {
@@ -3722,7 +3850,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "mem": {
@@ -3731,9 +3859,9 @@
       "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^1.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "0.1.3",
+        "mimic-fn": "1.2.0",
+        "p-is-promise": "2.0.0"
       }
     },
     "meow": {
@@ -3742,15 +3870,15 @@
       "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist": "^1.1.3",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0"
+        "camelcase-keys": "4.2.0",
+        "decamelize-keys": "1.1.0",
+        "loud-rejection": "1.6.0",
+        "minimist": "1.2.0",
+        "minimist-options": "3.0.2",
+        "normalize-package-data": "2.4.2",
+        "read-pkg-up": "3.0.0",
+        "redent": "2.0.0",
+        "trim-newlines": "2.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -3773,19 +3901,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "mime-db": {
@@ -3800,7 +3928,7 @@
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.37.0"
       }
     },
     "mimic-fn": {
@@ -3815,7 +3943,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -3830,8 +3958,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "minipass": {
@@ -3840,8 +3968,8 @@
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
       },
       "dependencies": {
         "yallist": {
@@ -3858,7 +3986,7 @@
       "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "dev": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.5"
       }
     },
     "mississippi": {
@@ -3867,16 +3995,16 @@
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^3.0.0",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
+        "concat-stream": "1.6.2",
+        "duplexify": "3.6.1",
+        "end-of-stream": "1.4.1",
+        "flush-write-stream": "1.0.3",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "3.0.0",
+        "pumpify": "1.5.1",
+        "stream-each": "1.2.3",
+        "through2": "2.0.5"
       }
     },
     "mixin-deep": {
@@ -3885,8 +4013,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3895,14 +4023,14 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -3921,12 +4049,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.3",
+        "run-queue": "1.0.3"
       }
     },
     "ms": {
@@ -3941,10 +4069,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "mute-stream": {
@@ -3959,17 +4087,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "nice-try": {
@@ -3978,15 +4106,21 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "dev": true
+    },
     "node-fetch-npm": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
       "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
       "dev": true,
       "requires": {
-        "encoding": "^0.1.11",
-        "json-parse-better-errors": "^1.0.0",
-        "safe-buffer": "^5.1.1"
+        "encoding": "0.1.12",
+        "json-parse-better-errors": "1.0.2",
+        "safe-buffer": "5.1.2"
       }
     },
     "node-gyp": {
@@ -3995,23 +4129,23 @@
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
+        "fstream": "1.0.11",
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.15",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.5",
+        "request": "2.88.0",
+        "rimraf": "2.6.3",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.1"
       },
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -4023,7 +4157,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -4032,10 +4166,10 @@
       "integrity": "sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.6.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "npm-bundled": {
@@ -4050,14 +4184,14 @@
       "integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
       "dev": true,
       "requires": {
-        "byline": "^5.0.0",
-        "graceful-fs": "^4.1.11",
-        "node-gyp": "^3.8.0",
-        "resolve-from": "^4.0.0",
-        "slide": "^1.1.6",
+        "byline": "5.0.0",
+        "graceful-fs": "4.1.15",
+        "node-gyp": "3.8.0",
+        "resolve-from": "4.0.0",
+        "slide": "1.1.6",
         "uid-number": "0.0.6",
-        "umask": "^1.1.0",
-        "which": "^1.3.1"
+        "umask": "1.1.0",
+        "which": "1.3.1"
       }
     },
     "npm-logical-tree": {
@@ -4072,10 +4206,10 @@
       "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.6.0",
-        "osenv": "^0.1.5",
-        "semver": "^5.5.0",
-        "validate-npm-package-name": "^3.0.0"
+        "hosted-git-info": "2.7.1",
+        "osenv": "0.1.5",
+        "semver": "5.6.0",
+        "validate-npm-package-name": "3.0.0"
       }
     },
     "npm-packlist": {
@@ -4084,8 +4218,8 @@
       "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
       "dev": true,
       "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.5"
       }
     },
     "npm-pick-manifest": {
@@ -4094,9 +4228,9 @@
       "integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1",
-        "npm-package-arg": "^6.0.0",
-        "semver": "^5.4.1"
+        "figgy-pudding": "3.5.1",
+        "npm-package-arg": "6.1.0",
+        "semver": "5.6.0"
       }
     },
     "npm-profile": {
@@ -4105,9 +4239,9 @@
       "integrity": "sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.2 || 2",
-        "figgy-pudding": "^3.4.1",
-        "npm-registry-fetch": "^3.8.0"
+        "aproba": "1.2.0",
+        "figgy-pudding": "3.5.1",
+        "npm-registry-fetch": "3.9.0"
       }
     },
     "npm-registry-fetch": {
@@ -4116,12 +4250,12 @@
       "integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.3.4",
-        "bluebird": "^3.5.1",
-        "figgy-pudding": "^3.4.1",
-        "lru-cache": "^4.1.3",
-        "make-fetch-happen": "^4.0.1",
-        "npm-package-arg": "^6.1.0"
+        "JSONStream": "1.3.5",
+        "bluebird": "3.5.3",
+        "figgy-pudding": "3.5.1",
+        "lru-cache": "4.1.5",
+        "make-fetch-happen": "4.0.1",
+        "npm-package-arg": "6.1.0"
       }
     },
     "npm-run-path": {
@@ -4130,7 +4264,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -4139,10 +4273,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -4169,9 +4303,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -4180,7 +4314,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -4189,7 +4323,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4200,7 +4334,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.pick": {
@@ -4209,8 +4343,14 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
+    },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -4218,7 +4358,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -4227,7 +4367,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optimist": {
@@ -4236,8 +4376,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "os-homedir": {
@@ -4252,9 +4392,19 @@
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
+        "execa": "1.0.0",
+        "lcid": "2.0.0",
+        "mem": "4.1.0"
+      }
+    },
+    "os-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
+      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+      "dev": true,
+      "requires": {
+        "macos-release": "2.0.0",
+        "windows-release": "3.1.0"
       }
     },
     "os-tmpdir": {
@@ -4269,8 +4419,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "p-defer": {
@@ -4297,7 +4447,7 @@
       "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
       "dev": true,
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.0.0"
       }
     },
     "p-locate": {
@@ -4306,7 +4456,7 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.1.0"
       }
     },
     "p-map": {
@@ -4321,7 +4471,7 @@
       "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
       "dev": true,
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "p-pipe": {
@@ -4348,7 +4498,7 @@
       "integrity": "sha1-ftlLPOszMngjU69qrhGqn8I1uwA=",
       "dev": true,
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "pacote": {
@@ -4357,33 +4507,33 @@
       "integrity": "sha512-YKSRsQqmeHxgra0KCdWA2FtVxDPUlBiCdmew+mSe44pzlx5t1ViRMWiQg18T+DREA+vSqYfKzynaToFR4hcKHw==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.3",
-        "cacache": "^11.3.2",
-        "figgy-pudding": "^3.5.1",
-        "get-stream": "^4.1.0",
-        "glob": "^7.1.3",
-        "lru-cache": "^5.1.1",
-        "make-fetch-happen": "^4.0.1",
-        "minimatch": "^3.0.4",
-        "minipass": "^2.3.5",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "normalize-package-data": "^2.4.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.1.12",
-        "npm-pick-manifest": "^2.2.3",
-        "npm-registry-fetch": "^3.8.0",
-        "osenv": "^0.1.5",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^1.1.1",
-        "protoduck": "^5.0.1",
-        "rimraf": "^2.6.2",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.6.0",
-        "ssri": "^6.0.1",
-        "tar": "^4.4.8",
-        "unique-filename": "^1.1.1",
-        "which": "^1.3.1"
+        "bluebird": "3.5.3",
+        "cacache": "11.3.2",
+        "figgy-pudding": "3.5.1",
+        "get-stream": "4.1.0",
+        "glob": "7.1.3",
+        "lru-cache": "5.1.1",
+        "make-fetch-happen": "4.0.1",
+        "minimatch": "3.0.4",
+        "minipass": "2.3.5",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "normalize-package-data": "2.4.2",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.2.0",
+        "npm-pick-manifest": "2.2.3",
+        "npm-registry-fetch": "3.9.0",
+        "osenv": "0.1.5",
+        "promise-inflight": "1.0.1",
+        "promise-retry": "1.1.1",
+        "protoduck": "5.0.1",
+        "rimraf": "2.6.3",
+        "safe-buffer": "5.1.2",
+        "semver": "5.6.0",
+        "ssri": "6.0.1",
+        "tar": "4.4.8",
+        "unique-filename": "1.1.1",
+        "which": "1.3.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -4392,7 +4542,7 @@
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
+            "yallist": "3.0.3"
           }
         },
         "tar": {
@@ -4401,13 +4551,13 @@
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "yallist": {
@@ -4424,9 +4574,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "~0.2.2",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "parse-github-repo-url": {
@@ -4441,8 +4591,8 @@
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.2",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "pascalcase": {
@@ -4493,7 +4643,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "performance-now": {
@@ -4520,7 +4670,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -4529,7 +4679,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -4538,7 +4688,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "locate-path": {
@@ -4547,8 +4697,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -4557,7 +4707,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -4566,7 +4716,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -4601,8 +4751,8 @@
       "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "dev": true,
       "requires": {
-        "err-code": "^1.0.0",
-        "retry": "^0.10.0"
+        "err-code": "1.1.2",
+        "retry": "0.10.1"
       }
     },
     "promzard": {
@@ -4611,7 +4761,7 @@
       "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "dev": true,
       "requires": {
-        "read": "1"
+        "read": "1.0.7"
       }
     },
     "proto-list": {
@@ -4626,7 +4776,7 @@
       "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
       "dev": true,
       "requires": {
-        "genfun": "^5.0.0"
+        "genfun": "5.0.0"
       }
     },
     "pseudomap": {
@@ -4647,8 +4797,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -4657,9 +4807,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.6.1",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       },
       "dependencies": {
         "pump": {
@@ -4668,8 +4818,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -4692,6 +4842,12 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+      "dev": true
+    },
     "quick-lru": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
@@ -4704,7 +4860,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-cmd-shim": {
@@ -4713,7 +4869,7 @@
       "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2"
+        "graceful-fs": "4.1.15"
       }
     },
     "read-package-json": {
@@ -4722,11 +4878,11 @@
       "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "json-parse-better-errors": "^1.0.1",
-        "normalize-package-data": "^2.0.0",
-        "slash": "^1.0.0"
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.15",
+        "json-parse-better-errors": "1.0.2",
+        "normalize-package-data": "2.4.2",
+        "slash": "1.0.0"
       }
     },
     "read-package-tree": {
@@ -4735,11 +4891,11 @@
       "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
       "dev": true,
       "requires": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "once": "^1.3.0",
-        "read-package-json": "^2.0.0",
-        "readdir-scoped-modules": "^1.0.0"
+        "debuglog": "1.0.1",
+        "dezalgo": "1.0.3",
+        "once": "1.4.0",
+        "read-package-json": "2.0.13",
+        "readdir-scoped-modules": "1.0.2"
       }
     },
     "read-pkg": {
@@ -4748,9 +4904,9 @@
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.2",
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
@@ -4759,8 +4915,8 @@
       "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "3.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -4769,7 +4925,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "locate-path": {
@@ -4778,8 +4934,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -4788,7 +4944,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -4797,7 +4953,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -4810,17 +4966,17 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdir-scoped-modules": {
@@ -4829,10 +4985,10 @@
       "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
       "dev": true,
       "requires": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
+        "debuglog": "1.0.1",
+        "dezalgo": "1.0.3",
+        "graceful-fs": "4.1.15",
+        "once": "1.4.0"
       }
     },
     "redent": {
@@ -4841,9 +4997,15 @@
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
-        "indent-string": "^3.0.0",
-        "strip-indent": "^2.0.0"
+        "indent-string": "3.2.0",
+        "strip-indent": "2.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -4851,8 +5013,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "repeat-element": {
@@ -4873,7 +5035,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -4882,26 +5044,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.21",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "require-directory": {
@@ -4916,13 +5078,19 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
     "resolve": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
       "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-cwd": {
@@ -4931,7 +5099,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -4960,8 +5128,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -4982,7 +5150,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.3"
       }
     },
     "run-async": {
@@ -4991,7 +5159,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-queue": {
@@ -5000,7 +5168,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1"
+        "aproba": "1.2.0"
       }
     },
     "rxjs": {
@@ -5009,7 +5177,7 @@
       "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "safe-buffer": {
@@ -5020,11 +5188,11 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -5051,10 +5219,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5063,7 +5231,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -5074,7 +5242,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -5113,14 +5281,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -5138,7 +5306,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -5147,7 +5315,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -5164,9 +5332,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -5175,7 +5343,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -5184,7 +5352,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5193,7 +5361,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5202,9 +5370,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -5215,7 +5383,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5224,7 +5392,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5235,7 +5403,7 @@
       "integrity": "sha512-+2r83WaRT3PXYoO/1z+RDEBE7Z2f9YcdQnJ0K/ncXXbV5gJ6wYfNAebYFYiiUjM6E4JyXnPY8cimwyvFYHVUUA==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.5",
+        "ip": "1.1.5",
         "smart-buffer": "4.0.2"
       }
     },
@@ -5245,8 +5413,8 @@
       "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
       "dev": true,
       "requires": {
-        "agent-base": "~4.2.0",
-        "socks": "~2.2.0"
+        "agent-base": "4.2.1",
+        "socks": "2.2.3"
       }
     },
     "sort-keys": {
@@ -5255,7 +5423,7 @@
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-map": {
@@ -5270,11 +5438,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-url": {
@@ -5289,8 +5457,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.3"
       }
     },
     "spdx-exceptions": {
@@ -5305,8 +5473,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.3"
       }
     },
     "spdx-license-ids": {
@@ -5321,7 +5489,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split-string": {
@@ -5330,7 +5498,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "split2": {
@@ -5339,7 +5507,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "^2.0.2"
+        "through2": "2.0.5"
       }
     },
     "sprintf-js": {
@@ -5354,15 +5522,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "ssri": {
@@ -5371,7 +5539,7 @@
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1"
+        "figgy-pudding": "3.5.1"
       }
     },
     "static-extend": {
@@ -5380,8 +5548,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -5390,7 +5558,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -5401,8 +5569,8 @@
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "stream-shift": "1.0.0"
       }
     },
     "stream-shift": {
@@ -5417,9 +5585,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -5428,7 +5596,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringify-package": {
@@ -5439,11 +5607,11 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -5470,9 +5638,9 @@
       "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
       "dev": true,
       "requires": {
-        "duplexer": "^0.1.1",
-        "minimist": "^1.2.0",
-        "through": "^2.3.4"
+        "duplexer": "0.1.1",
+        "minimist": "1.2.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "minimist": {
@@ -5489,7 +5657,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "tar": {
@@ -5498,9 +5666,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
       }
     },
     "temp-dir": {
@@ -5515,12 +5683,12 @@
       "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "is-stream": "^1.1.0",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "temp-dir": "^1.0.0",
-        "uuid": "^3.0.1"
+        "graceful-fs": "4.1.15",
+        "is-stream": "1.1.0",
+        "make-dir": "1.3.0",
+        "pify": "3.0.0",
+        "temp-dir": "1.0.0",
+        "uuid": "3.3.2"
       }
     },
     "text-extensions": {
@@ -5531,7 +5699,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -5541,8 +5709,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "tmp": {
@@ -5551,7 +5719,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-object-path": {
@@ -5560,7 +5728,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5569,7 +5737,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5580,10 +5748,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -5592,8 +5760,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "tough-cookie": {
@@ -5602,8 +5770,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.31",
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -5620,7 +5788,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "trim-newlines": {
@@ -5647,18 +5815,18 @@
       "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.1",
+        "commander": "2.17.1",
+        "diff": "3.5.0",
+        "glob": "7.1.3",
+        "js-yaml": "3.12.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.10.0",
+        "semver": "5.6.0",
+        "tslib": "1.9.3",
+        "tsutils": "2.29.0"
       }
     },
     "tsutils": {
@@ -5667,7 +5835,7 @@
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.3"
       }
     },
     "tunnel-agent": {
@@ -5676,7 +5844,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -5704,8 +5872,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
-        "source-map": "~0.6.1"
+        "commander": "2.17.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -5735,10 +5903,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5747,7 +5915,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -5756,10 +5924,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -5770,7 +5938,7 @@
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "2.0.1"
       }
     },
     "unique-slug": {
@@ -5779,7 +5947,16 @@
       "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
       "dev": true,
       "requires": {
-        "imurmurhash": "^0.1.4"
+        "imurmurhash": "0.1.4"
+      }
+    },
+    "universal-user-agent": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
+      "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
+      "dev": true,
+      "requires": {
+        "os-name": "3.0.0"
       }
     },
     "universalify": {
@@ -5794,8 +5971,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -5804,9 +5981,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -5834,13 +6011,29 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "dev": true,
+      "requires": {
+        "querystringify": "2.1.0",
+        "requires-port": "1.0.0"
+      }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
       "dev": true
     },
     "use": {
@@ -5867,8 +6060,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validate-npm-package-name": {
@@ -5877,7 +6070,7 @@
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
-        "builtins": "^1.0.3"
+        "builtins": "1.0.3"
       }
     },
     "verror": {
@@ -5886,9 +6079,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "wcwidth": {
@@ -5897,7 +6090,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.3"
+        "defaults": "1.0.3"
       }
     },
     "webidl-conversions": {
@@ -5912,9 +6105,9 @@
       "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "which": {
@@ -5923,7 +6116,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -5938,7 +6131,39 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "1.0.2"
+      }
+    },
+    "windows-release": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
+      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+      "dev": true,
+      "requires": {
+        "execa": "0.10.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
       }
     },
     "wordwrap": {
@@ -5949,12 +6174,12 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -5969,9 +6194,9 @@
       "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.15",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "write-json-file": {
@@ -5980,12 +6205,12 @@
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
-        "detect-indent": "^5.0.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "sort-keys": "^2.0.0",
-        "write-file-atomic": "^2.0.0"
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.1.15",
+        "make-dir": "1.3.0",
+        "pify": "3.0.0",
+        "sort-keys": "2.0.0",
+        "write-file-atomic": "2.4.2"
       }
     },
     "write-pkg": {
@@ -5994,8 +6219,8 @@
       "integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
       "dev": true,
       "requires": {
-        "sort-keys": "^2.0.0",
-        "write-json-file": "^2.2.0"
+        "sort-keys": "2.0.0",
+        "write-json-file": "2.3.0"
       }
     },
     "xtend": {
@@ -6022,18 +6247,18 @@
       "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "3.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "11.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6075,8 +6300,8 @@
       "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.0.0",
+        "decamelize": "1.2.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "Apache-2.0",
   "repository": "github:improbable-eng/grpc-web",
   "devDependencies": {
+    "github-release-cli": "^1.0.1",
     "lerna": "^3.4.3",
     "tslint": "^5.11.0",
     "typescript": "^3.1.6"

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -19,8 +19,13 @@ fi
 
 echo "Generating grpcwebproxy binaries"
 cd go
-./generate-grpcwebproxy-binaries.sh
-ls -l ./build
+rm -rf dist
+mkdir -p dist
+
+GOOS=linux GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-linux-amd64" ./grpcwebproxy
+GOOS=windows GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-windows-amd64.exe" ./grpcwebproxy
+GOOS=darwin GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-darwin-amd64" ./grpcwebproxy
+ls -l ./dist
 cd ..
 
 echo "Publishing $TAG"
@@ -32,7 +37,7 @@ echo "Publishing $TAG"
   --tag "$TAG" \
   --name "$TAG" \
   --body "See [CHANGELOG](https://github.com/improbable-eng/grpc-web/blob/master/CHANGELOG.md) for details" \
-  go/build/*
+  go/dist/*
 
 # Publish client modules to NPM.
 npx lerna publish $TAG --yes

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -22,9 +22,9 @@ cd go
 rm -rf dist
 mkdir -p dist
 
-GOOS=linux GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-linux-amd64" ./grpcwebproxy
-GOOS=windows GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-windows-amd64.exe" ./grpcwebproxy
-GOOS=darwin GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-darwin-amd64" ./grpcwebproxy
+GOOS=linux GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-linux-x86_64" ./grpcwebproxy
+GOOS=windows GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-windows-x86_64.exe" ./grpcwebproxy
+GOOS=darwin GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-darwin-x86_64" ./grpcwebproxy
 ls -l ./dist
 cd ..
 

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  echo "GITHUB_TOKEN not found in environment"
+  exit 1
+fi
+
 TAG=$1
 if [[ -z "$TAG" ]]; then
   echo "Expected release tag to be passed as the first argument"
@@ -27,7 +32,7 @@ echo "Publishing $TAG"
   --tag "$TAG" \
   --name "$TAG" \
   --body "See [CHANGELOG](https://github.com/improbable-eng/grpc-web/blob/master/CHANGELOG.md) for details" \
-  "go/build/*"
+  go/build/*
 
 # Publish client modules to NPM.
 npx lerna publish $TAG --yes

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -23,8 +23,9 @@ rm -rf dist
 mkdir -p dist
 
 GOOS=linux GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-linux-x86_64" ./grpcwebproxy
-GOOS=windows GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-windows-x86_64.exe" ./grpcwebproxy
-GOOS=darwin GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-darwin-x86_64" ./grpcwebproxy
+GOOS=windows GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-win64.exe" ./grpcwebproxy
+GOOS=darwin GOARCH=amd64 go build -o "dist/grpcwebproxy-$TAG-osx-x86_64" ./grpcwebproxy
+for f in dist/*; do zip -9r "$f.zip" "$f"; done
 ls -l ./dist
 cd ..
 
@@ -37,7 +38,7 @@ echo "Publishing $TAG"
   --tag "$TAG" \
   --name "$TAG" \
   --body "See [CHANGELOG](https://github.com/improbable-eng/grpc-web/blob/master/CHANGELOG.md) for details" \
-  go/dist/*
+  go/dist/*.zip
 
 # Publish client modules to NPM.
 npx lerna publish $TAG --yes

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+TAG=$1
+if [[ -z "$TAG" ]]; then
+  echo "Expected release tag to be passed as the first argument"
+  exit 1
+fi
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid release tag: $TAG"
+  exit 1
+fi
+
+echo "Generating grpcwebproxy binaries"
+cd go
+./generate-grpcwebproxy-binaries.sh
+ls -l ./build
+cd ..
+
+echo "Publishing $TAG"
+
+# Create github release and attach server binaries
+./node_modules/.bin/github-release upload \
+  --owner improbable-eng \
+  --repo grpc-web \
+  --tag "$TAG" \
+  --name "$TAG" \
+  --body "See [CHANGELOG](https://github.com/improbable-eng/grpc-web/blob/master/CHANGELOG.md) for details" \
+  "go/build/*"
+
+# Publish client modules to NPM.
+npx lerna publish $TAG --yes


### PR DESCRIPTION
- Triggered by travis when a new tag matching v*X.y.z* is pushed.
- Generates grpcwebproxy binaries for win, mac, and linux
- Uses `github-release` binary to do what it says on the tin and attach the grpcwebproxy binaries to the release
- Uses `lerna publish` to publish the client packages to npm

### TODO
- [ ] Verify that this works locally by publishing v0.9.0 to NPM and github
- [ ] Inject credentials into travis for creating github releases
