### PR TITLE
Ensure headers from wrapped server is forwarded appropriately

### DIFF
--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -45,13 +45,15 @@ func (w *grpcWebResponse) Header() http.Header {
 }
 
 func (w *grpcWebResponse) Write(b []byte) (int, error) {
-	w.wroteBody = true
+	if !w.wroteHeaders {
+		w.prepareHeaders()
+	}
+	w.wroteBody, w.wroteHeaders = true, true
 	return w.wrapped.Write(b)
 }
 
 func (w *grpcWebResponse) WriteHeader(code int) {
-	w.copyJustHeadersToWrapped()
-	w.writeCorsExposedHeaders()
+	w.prepareHeaders()
 	w.wrapped.WriteHeader(code)
 	w.wroteHeaders = true
 }
@@ -68,63 +70,34 @@ func (w *grpcWebResponse) CloseNotify() <-chan bool {
 	return w.wrapped.(http.CloseNotifier).CloseNotify()
 }
 
-func (w *grpcWebResponse) copyJustHeadersToWrapped() {
-	wrappedHeader := w.wrapped.Header()
-	for k, vv := range w.headers {
-		// Skip the pre-annoucement of Trailer headers. Don't add them to the response headers.
-		if strings.ToLower(k) == "trailer" {
-			continue
-		}
-		// Convert the content-type to the appropriate kind
-		if strings.ToLower(k) == "content-type" {
-			vv[0] = strings.Replace(vv[0], grpcContentType, w.contentType, 1)
-		}
-		for _, v := range vv {
-			wrappedHeader.Add(k, v)
-		}
-	}
+// prepareHeaders runs all required header copying and transformations to
+// prepare the header of the wrapped response writer.
+func (w *grpcWebResponse) prepareHeaders() {
+	wh := w.wrapped.Header()
+	copyHeader(
+		wh, w.headers,
+		skipKeys("trailer"),
+		replaceInKeys(http2.TrailerPrefix, ""),
+		replaceInVals("content-type", grpcContentType, w.contentType),
+		keyCase(http.CanonicalHeaderKey),
+	)
+	wh.Set(
+		http.CanonicalHeaderKey("access-control-expose-headers"),
+		strings.Join(headerKeys(wh), ", "),
+	)
 }
 
 func (w *grpcWebResponse) finishRequest(req *http.Request) {
 	if w.wroteHeaders || w.wroteBody {
 		w.copyTrailersToPayload()
 	} else {
-		w.copyTrailersAndHeadersToWrapped()
+		w.WriteHeader(http.StatusOK)
+		w.wrapped.(http.Flusher).Flush()
 	}
-}
-
-func (w *grpcWebResponse) copyTrailersAndHeadersToWrapped() {
-	w.wroteHeaders = true
-	wrappedHeader := w.wrapped.Header()
-	for k, vv := range w.headers {
-		// Skip the pre-annoucement of Trailer headers. Don't add them to the response headers.
-		if strings.ToLower(k) == "trailer" {
-			continue
-		}
-		// Skip the Trailer prefix
-		if strings.HasPrefix(k, http2.TrailerPrefix) {
-			k = k[len(http2.TrailerPrefix):]
-		}
-		for _, v := range vv {
-			wrappedHeader.Add(k, v)
-		}
-	}
-	w.writeCorsExposedHeaders()
-	w.wrapped.WriteHeader(http.StatusOK)
-	w.wrapped.(http.Flusher).Flush()
-}
-
-func (w *grpcWebResponse) writeCorsExposedHeaders() {
-	// These cors handlers are added to the *response*, not a preflight.
-	knownHeaders := []string{}
-	for h := range w.wrapped.Header() {
-		knownHeaders = append(knownHeaders, http.CanonicalHeaderKey(h))
-	}
-	w.wrapped.Header().Set("Access-Control-Expose-Headers", strings.Join(knownHeaders, ", "))
 }
 
 func (w *grpcWebResponse) copyTrailersToPayload() {
-	trailers := w.extractTrailerHeaders()
+	trailers := extractTrailingHeaders(w.headers, w.wrapped.Header())
 	trailerBuffer := new(bytes.Buffer)
 	trailers.Write(trailerBuffer)
 	trailerGrpcDataHeader := []byte{1 << 7, 0, 0, 0, 0} // MSB=1 indicates this is a trailer data frame.
@@ -134,27 +107,18 @@ func (w *grpcWebResponse) copyTrailersToPayload() {
 	w.wrapped.(http.Flusher).Flush()
 }
 
-func (w *grpcWebResponse) extractTrailerHeaders() trailer {
-	flushedHeaders := w.wrapped.Header()
-	trailerHeaders := trailer{make(http.Header)}
-	for k, vv := range w.headers {
-		// Skip the pre-annoucement of Trailer headers. Don't add them to the response headers.
-		if strings.ToLower(k) == "trailer" {
-			continue
-		}
-		// Skip existing headers that were already sent.
-		if _, exists := flushedHeaders[k]; exists {
-			continue
-		}
-		// Skip the Trailer prefix
-		if strings.HasPrefix(k, http2.TrailerPrefix) {
-			k = k[len(http2.TrailerPrefix):]
-		}
-		for _, v := range vv {
-			trailerHeaders.Add(k, v)
-		}
-	}
-	return trailerHeaders
+func extractTrailingHeaders(src http.Header, flushed http.Header) http.Header {
+	th := make(http.Header)
+	copyHeader(
+		th, src,
+		skipKeys(append([]string{"trailer"}, headerKeys(flushed)...)...),
+		replaceInKeys(http2.TrailerPrefix, ""),
+		// gRPC-Web spec says that must use lower-case header/trailer names. See
+		// "HTTP wire protocols" section in
+		// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+		keyCase(strings.ToLower),
+	)
+	return th
 }
 
 // An http.ResponseWriter wrapper that writes base64-encoded payloads. You must call Flush()

--- a/go/grpcweb/header.go
+++ b/go/grpcweb/header.go
@@ -1,0 +1,140 @@
+//Copyright 2018 Improbable. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpcweb
+
+import (
+	"net/http"
+	"strings"
+)
+
+// replacer is the function that replaces the key and the slice of strings
+// per the header item. This function returns false as the last return value
+// if neither the key nor the slice were replaced.
+type replacer func(key string, vv []string) (string, []string, bool)
+
+// copyOptions acts as a storage for copyHeader options.
+type copyOptions struct {
+	skipKeys  map[string]bool
+	replacers []replacer
+}
+
+// copyOption is the option type to pass to copyHeader function.
+type copyOption func(*copyOptions)
+
+// skipKeys returns an option to skip specified keys when copying headers
+// with copyHeader function. Key matching in the source header is
+// case-insensitive.
+func skipKeys(keys ...string) copyOption {
+	return func(opts *copyOptions) {
+		if opts.skipKeys == nil {
+			opts.skipKeys = make(map[string]bool)
+		}
+		for _, k := range keys {
+			// normalize the key
+			opts.skipKeys[strings.ToLower(k)] = true
+		}
+	}
+}
+
+// replaceInVals returns an option to replace old substring with new substring
+// in header values keyed with key. Key matching in the header is
+// case-insensitive.
+func replaceInVals(key, old, new string) copyOption {
+	return func(opts *copyOptions) {
+		opts.replacers = append(
+			opts.replacers,
+			func(k string, vv []string) (string, []string, bool) {
+				if strings.ToLower(key) == strings.ToLower(k) {
+					vv2 := make([]string, 0, len(vv))
+					for _, v := range vv {
+						vv2 = append(
+							vv2,
+							strings.Replace(v, old, new, 1),
+						)
+					}
+					return k, vv2, true
+				}
+				return "", nil, false
+			},
+		)
+	}
+}
+
+// replaceInKeys returns an option to replace an old substring with a new
+// substring in header keys.
+func replaceInKeys(old, new string) copyOption {
+	return func(opts *copyOptions) {
+		opts.replacers = append(
+			opts.replacers,
+			func(k string, vv []string) (string, []string, bool) {
+				if strings.Contains(k, old) {
+					return strings.Replace(k, old, new, 1), vv, true
+				}
+				return "", nil, false
+			},
+		)
+	}
+}
+
+// keyCase returns an option to unconditionally modify the case of the
+// destination header keys with function fn. Typically fn can be
+// strings.ToLower, strings.ToUpper, http.CanonicalHeaderKey
+func keyCase(fn func(string) string) copyOption {
+	return func(opts *copyOptions) {
+		opts.replacers = append(
+			opts.replacers,
+			func(k string, vv []string) (string, []string, bool) {
+				return fn(k), vv, true
+			},
+		)
+	}
+}
+
+// keyTrim returns an option to unconditionally trim the keys of the
+// destination header with function fn. Typically fn can be
+// strings.Trim, strings.TrimLeft/TrimRight, strings.TrimPrefix/TrimSuffix
+func keyTrim(fn func(string, string) string, cut string) copyOption {
+	return func(opts *copyOptions) {
+		opts.replacers = append(
+			opts.replacers,
+			func(k string, vv []string) (string, []string, bool) {
+				return fn(k, cut), vv, true
+			},
+		)
+	}
+}
+
+// copyHeader copies src to dst header. This function does not uses http.Header
+// methods internally, so header keys are copied as is. If any key normalization
+// is required, use keyCase option.
+func copyHeader(
+	dst, src http.Header,
+	opts ...copyOption,
+) {
+	options := new(copyOptions)
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	for k, vv := range src {
+		if options.skipKeys[strings.ToLower(k)] {
+			continue
+		}
+		for _, r := range options.replacers {
+			if k2, vv2, ok := r(k, vv); ok {
+				k, vv = k2, vv2
+			}
+		}
+		dst[k] = vv
+	}
+}
+
+// headerKeys returns a slice of strings representing the keys in the header h.
+func headerKeys(h http.Header) []string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
Fix #334.

This approach adds 'copyHeader' function with multiple options to address repeatable code in `go/grpcweb/grpc_web_response.go` file and header preparation when underlying gRPC service calls `Write` method on `grpcWebResponse` object.

The tests were copied from #339  originally done by @johanbrandhorst.