### PR TITLE
Remove content-length header

### DIFF
--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -225,6 +225,11 @@ func hackIntoNormalGrpcRequest(req *http.Request) (*http.Request, bool) {
 	}
 	req.Header.Set("content-type", strings.Replace(contentType, incomingContentType, grpcContentType, 1))
 
+	// Remove content-length header since it represents http1.1 payload size, not the sum of the h2
+	// DATA frame payload lengths. https://http2.github.io/http2-spec/#malformed This effectively
+	// switches to chunked encoding which is the default for h2
+	req.Header.Del("content-length")
+
 	return req, isTextFormat
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
Move the patch from envoy proxy.
https://sourcegraph.com/github.com/envoyproxy/envoy@cfc514546bc0284536893cca5fa43d7128edcd35/-/blob/source/extensions/filters/http/grpc_web/grpc_web_filter.cc#L51
<!-- Enumerate changes you made -->

## Verification
I tried the patch locally and check the content-length has been removed.
<!-- How you tested it? How do you know it works? -->
