### PR TITLE
Worker error "window not defined" fix

### DIFF
--- a/client/grpc-web/webpack.config.js
+++ b/client/grpc-web/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = [{
       filename: `grpc-web-client.js`,
       path: DIST_DIR,
       libraryTarget: 'commonjs',
+      globalObject: 'this',
     }
   },
   {
@@ -32,6 +33,7 @@ module.exports = [{
       filename: `grpc-web-client.umd.js`,
       path: DIST_DIR,
       libraryTarget: 'umd',
+      globalObject: 'this',
     }
   },
 ];


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Added support to use in service workers

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
