### PR TITLE
Set Content-Length header in NodeHTTPTransport to disable chunked encoding

### DIFF
--- a/client/grpc-web-node-http-transport/src/index.ts
+++ b/client/grpc-web-node-http-transport/src/index.ts
@@ -18,6 +18,7 @@ class NodeHttp implements grpc.Transport {
   }
 
   sendMessage(msgBytes: Uint8Array) {
+    this.request.setHeader("Content-Length", msgBytes.byteLength);
     this.request.write(toBuffer(msgBytes));
     this.request.end();
   }

--- a/client/grpc-web-node-http-transport/src/index.ts
+++ b/client/grpc-web-node-http-transport/src/index.ts
@@ -18,7 +18,10 @@ class NodeHttp implements grpc.Transport {
   }
 
   sendMessage(msgBytes: Uint8Array) {
-    this.request.setHeader("Content-Length", msgBytes.byteLength);
+    if (!this.options.methodDefinition.requestStream  && !this.options.methodDefinition.responseStream) {
+        // Disable chunked encoding if we are not using streams
+        this.request.setHeader("Content-Length", msgBytes.byteLength);
+    }
     this.request.write(toBuffer(msgBytes));
     this.request.end();
   }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Disable Chunked http encoding for unary requests in NodeHttpTransport.

Chunked encoding is only useful when we do not know what the size of our message will be. Using Raw http encoding means less overall data sent which should be more efficient.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding#Chunked_encoding

Setting the Content-Length will disable node's http library default chunked encoding:

https://nodejs.org/api/http.html#http_http_request_url_options_callback

## Verification

Tested it locally with my own project.
