### PR TITLE
Replace travis_retry with custom retry script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
 before_script:
   - ./integration_test/start-testserver.sh &
 script:
-  - travis_retry npm run test:integration
+  - npm run test:integration
 
 stages:
   - lint

--- a/integration_test/package.json
+++ b/integration_test/package.json
@@ -10,7 +10,7 @@
     "build:dev": "cd ts && rm -rf build && webpack-cli --watch",
     "build:node": "cd ts && rm -rf build-node && (cd node-src && tsc) && (cp _proto/improbable/grpcweb/test/test_pb.js build-node/integration_test/ts/_proto/improbable/grpcweb/test/test_pb.js)",
     "build": "npm run build:proto && npm run build:ts && npm run build:node",
-    "test": "./test.sh",
+    "start": "./test.sh",
     "test:browser": "./run-with-testserver.sh karma start ./karma.conf.ts --single-run",
     "test:node": "./run-with-testserver.sh jasmine ts/build-node/integration_test/ts/node-src/node.spec.js",
     "test:dev": "npm run build && ./run-with-testserver.sh karma start ./karma.conf.ts",

--- a/integration_test/test.sh
+++ b/integration_test/test.sh
@@ -1,21 +1,45 @@
 #!/bin/bash
 set -e
+set +o pipefail
+
+MAX_AUTO_RETRY=5
 
 npm run build
 
 if [ -z "$BROWSER" ]; then
-  # No environment is specified - run all tests
+  echo "No Browser specified, starting local test run"
   npm run test:node
   npm run test:browser
   exit 0
 fi
 
 if [ "$BROWSER" == "nodejs" ]; then
-  # Node is specified
   npm run test:node
   exit 0
 fi
 
-# A $BROWSER is specified - run only the browser tests
-npm run test:browser
+# inspired by https://unix.stackexchange.com/a/82602
+retry () {
+    local n=0
+
+    until [ $n -ge $MAX_AUTO_RETRY ]; do
+        set +e
+        "$@" && break
+        set -e
+
+        n=$[$n+1]
+        echo ''
+        echo retry $n of $MAX_AUTO_RETRY failed, trying again ...
+        echo ''
+    done
+
+    if [ $n -eq $MAX_AUTO_RETRY ]; then
+        echo "Giving up after ${MAX_AUTO_RETRY} retries"
+        exit 1
+    fi
+}
+
+# Note that browser tests in CI are very flaky, hence the need for the retry wrapper.
+retry npm run test:browser
+
 exit 0

--- a/integration_test/test.sh
+++ b/integration_test/test.sh
@@ -29,7 +29,7 @@ retry () {
 
         n=$[$n+1]
         echo ''
-        echo retry $n of $MAX_AUTO_RETRY failed, trying again ...
+        echo "Attempt ${n} of ${MAX_AUTO_RETRY} failed, trying again ..."
         echo ''
     done
 

--- a/integration_test/ts/src/spec.ts
+++ b/integration_test/ts/src/spec.ts
@@ -5,3 +5,5 @@ import "./unary.spec";
 import "./cancellation.spec";
 import "./detach.spec";
 import "./ChunkParser.spec";
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postbootstrap": "lerna run postbootstrap",
     "clean": "lerna clean --yes --private && lerna run clean",
     "test": "lerna run test",
-    "test:integration": "cd integration_test && npm run test",
+    "test:integration": "cd integration_test && npm run start",
     "lint": "tslint -c ./tslint.json ./client/**/*.ts ./integration_test/ts/*.ts ./integration_test/ts/**/*.ts"
   },
   "author": "Improbable",


### PR DESCRIPTION
- `travis_retry` is limited to 3 attempts, we need more - this change bumps it to 5.
- `travis_retry` does more work than strictly required as it re-builds the protos and integration-test bundle; now we only run the tests via karma.
- change the name of the integration_test script from `test` to `start` to ensure that integration tests are not executed during the unit test phase (as lerna will run `test` in *all* packages).