### PR TITLE
service worker fix for AbortController call

### DIFF
--- a/client/grpc-web/src/transports/http/fetch.ts
+++ b/client/grpc-web/src/transports/http/fetch.ts
@@ -26,7 +26,7 @@ class Fetch implements Transport {
   init: FetchTransportInit;
   reader: ReadableStreamReader;
   metadata: Metadata;
-  controller: AbortController | undefined = (window as any).AbortController && new AbortController();
+  controller: AbortController | undefined = (self as any).AbortController && new AbortController();
 
   constructor(transportOptions: TransportOptions, init: FetchTransportInit) {
     this.options = transportOptions;


### PR DESCRIPTION
window.AbortController changed to self.AbortController to work in both worker and window environments

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
