### PR TITLE
Set Content-Length in NodeHttpTransport

### DIFF
--- a/client/grpc-web-node-http-transport/src/index.ts
+++ b/client/grpc-web-node-http-transport/src/index.ts
@@ -18,6 +18,7 @@ class NodeHttp implements grpc.Transport {
   }
 
   sendMessage(msgBytes: Uint8Array) {
+    this.request.setHeader('Content-Length', msgBytes.byteLength);
     this.request.write(toBuffer(msgBytes));
     this.request.end();
   }


### PR DESCRIPTION
Since this transport only supports Unary requests from the client we can easily just set the Content-Length header just before the message is written to the XHR. This avoids Node falling back to chunked encoding which is generally horrible to deal with for servers.
