### PR TITLE
Allow non root resources

### DIFF
--- a/go/grpcweb/helpers.go
+++ b/go/grpcweb/helpers.go
@@ -40,7 +40,7 @@ func WebsocketRequestOrigin(req *http.Request) (string, error) {
 	return parsed.Host, nil
 }
 
-func GetGRPCEndpoint(req *http.Request) string {
+func getGRPCEndpoint(req *http.Request) string {
 	endpoint := pathMatcher.FindString(strings.TrimRight(req.URL.Path, "/"))
 	if len(endpoint) == 0 {
 		return req.URL.Path

--- a/go/grpcweb/helpers.go
+++ b/go/grpcweb/helpers.go
@@ -7,9 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strings"
 
 	"google.golang.org/grpc"
 )
+
+var pathMatcher = regexp.MustCompile(`/[^/]*/[^/]*$`)
 
 // ListGRPCResources is a helper function that lists all URLs that are registered on gRPC server.
 //
@@ -34,4 +38,13 @@ func WebsocketRequestOrigin(req *http.Request) (string, error) {
 		return "", fmt.Errorf("failed to parse url for grpc-websocket origin check: %q. error: %v", origin, err)
 	}
 	return parsed.Host, nil
+}
+
+func GetGRPCEndpoint(req *http.Request) string {
+	endpoint := pathMatcher.FindString(strings.TrimRight(req.URL.Path, "/"))
+	if len(endpoint) == 0 {
+		return req.URL.Path
+	}
+
+	return endpoint
 }

--- a/go/grpcweb/helpers_internal_test.go
+++ b/go/grpcweb/helpers_internal_test.go
@@ -22,7 +22,7 @@ func TestGetGRPCEndpoint(t *testing.T) {
 
 	for _, c := range cases {
 		req := httptest.NewRequest("GET", c.input, nil)
-		result := GetGRPCEndpoint(req)
+		result := getGRPCEndpoint(req)
 
 		assert.Equal(t, c.output, result)
 	}

--- a/go/grpcweb/helpers_internal_test.go
+++ b/go/grpcweb/helpers_internal_test.go
@@ -1,0 +1,29 @@
+package grpcweb
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetGRPCEndpoint(t *testing.T) {
+	cases := []struct {
+		input  string
+		output string
+	}{
+		{input: "/", output: "/"},
+		{input: "/resource", output: "/resource"},
+		{input: "/improbable.grpcweb.test.TestService/PingEmpty", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
+		{input: "/improbable.grpcweb.test.TestService/PingEmpty/", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
+		{input: "/a/b/c/improbable.grpcweb.test.TestService/PingEmpty", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
+		{input: "/a/b/c/improbable.grpcweb.test.TestService/PingEmpty/", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
+	}
+
+	for _, c := range cases {
+		req := httptest.NewRequest("GET", c.input, nil)
+		result := GetGRPCEndpoint(req)
+
+		assert.Equal(t, c.output, result)
+	}
+}

--- a/go/grpcweb/helpers_test.go
+++ b/go/grpcweb/helpers_test.go
@@ -4,7 +4,6 @@
 package grpcweb_test
 
 import (
-	"net/http/httptest"
 	"sort"
 	"testing"
 
@@ -34,25 +33,4 @@ func TestListGRPCResources(t *testing.T) {
 		expected,
 		actual,
 		"list grpc resources must provide an exhaustive list of all registered handlers")
-}
-
-func TestGetGRPCEndpoint(t *testing.T) {
-	cases := []struct {
-		input  string
-		output string
-	}{
-		{input: "/", output: "/"},
-		{input: "/resource", output: "/resource"},
-		{input: "/improbable.grpcweb.test.TestService/PingEmpty", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
-		{input: "/improbable.grpcweb.test.TestService/PingEmpty/", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
-		{input: "/a/b/c/improbable.grpcweb.test.TestService/PingEmpty", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
-		{input: "/a/b/c/improbable.grpcweb.test.TestService/PingEmpty/", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
-	}
-
-	for _, c := range cases {
-		req := httptest.NewRequest("GET", c.input, nil)
-		result := grpcweb.GetGRPCEndpoint(req)
-
-		assert.Equal(t, c.output, result)
-	}
 }

--- a/go/grpcweb/helpers_test.go
+++ b/go/grpcweb/helpers_test.go
@@ -51,7 +51,6 @@ func TestGetGRPCEndpoint(t *testing.T) {
 
 	for _, c := range cases {
 		req := httptest.NewRequest("GET", c.input, nil)
-
 		result := grpcweb.GetGRPCEndpoint(req)
 
 		assert.Equal(t, c.output, result)

--- a/go/grpcweb/helpers_test.go
+++ b/go/grpcweb/helpers_test.go
@@ -4,6 +4,7 @@
 package grpcweb_test
 
 import (
+	"net/http/httptest"
 	"sort"
 	"testing"
 
@@ -33,4 +34,27 @@ func TestListGRPCResources(t *testing.T) {
 		expected,
 		actual,
 		"list grpc resources must provide an exhaustive list of all registered handlers")
+}
+
+func TestGetGRPCEndpoint(t *testing.T) {
+	cases := []struct {
+		input  string
+		output string
+	}{
+		{input: "/", output: "/"},
+		{input: "/resource", output: "/resource"},
+		{input: "/improbable.grpcweb.test.TestService/PingEmpty", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
+		{input: "/improbable.grpcweb.test.TestService/PingEmpty/", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
+		{input: "/a/b/c/improbable.grpcweb.test.TestService/PingEmpty", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
+		{input: "/a/b/c/improbable.grpcweb.test.TestService/PingEmpty/", output: "/improbable.grpcweb.test.TestService/PingEmpty"},
+	}
+
+	for _, c := range cases {
+		req := httptest.NewRequest("GET", c.input, nil)
+
+		result := grpcweb.GetGRPCEndpoint(req)
+
+		assert.Equal(t, c.output, result)
+	}
+
 }

--- a/go/grpcweb/helpers_test.go
+++ b/go/grpcweb/helpers_test.go
@@ -55,5 +55,4 @@ func TestGetGRPCEndpoint(t *testing.T) {
 
 		assert.Equal(t, c.output, result)
 	}
-
 }

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -10,6 +10,7 @@ var (
 		allowedRequestHeaders:          []string{"*"},
 		corsForRegisteredEndpointsOnly: true,
 		originFunc:                     func(origin string) bool { return false },
+		allowNonRootResources:          false,
 	}
 )
 
@@ -19,6 +20,7 @@ type options struct {
 	originFunc                     func(origin string) bool
 	enableWebsockets               bool
 	websocketOriginFunc            func(req *http.Request) bool
+	allowNonRootResources          bool
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -97,5 +99,11 @@ func WithWebsockets(enableWebsockets bool) Option {
 func WithWebsocketOriginFunc(websocketOriginFunc func(req *http.Request) bool) Option {
 	return func(o *options) {
 		o.websocketOriginFunc = websocketOriginFunc
+	}
+}
+
+func WithAllowNonRootResource(allowNonRootResources bool) Option {
+	return func(o *options) {
+		o.allowNonRootResources = allowNonRootResources
 	}
 }

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -102,6 +102,12 @@ func WithWebsocketOriginFunc(websocketOriginFunc func(req *http.Request) bool) O
 	}
 }
 
+// WithAllowNonRootResource enables the gRPC wrapper to serve requests that have a path prefix
+// added to the URL, before the service name and method placeholders.
+//
+// This should be set to false when exposing the endpoint as the root resource, to avoid path processing.
+//
+// The default behaviour is `false`, i.e. always serves requests assuming there is no prefix to the gRPC endpoint.
 func WithAllowNonRootResource(allowNonRootResources bool) Option {
 	return func(o *options) {
 		o.allowNonRootResources = allowNonRootResources

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -105,7 +105,8 @@ func WithWebsocketOriginFunc(websocketOriginFunc func(req *http.Request) bool) O
 // WithAllowNonRootResource enables the gRPC wrapper to serve requests that have a path prefix
 // added to the URL, before the service name and method placeholders.
 //
-// This should be set to false when exposing the endpoint as the root resource, to avoid path processing.
+// This should be set to false when exposing the endpoint as the root resource, to avoid
+// the performance cost of path processing for every request.
 //
 // The default behaviour is `false`, i.e. always serves requests assuming there is no prefix to the gRPC endpoint.
 func WithAllowNonRootResource(allowNonRootResources bool) Option {

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -58,7 +58,10 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 		websocketOriginFunc = defaultWebsocketOriginFunc
 	}
 
-	endpointFunc := func(req *http.Request) string { return req.URL.Path }
+	endpointFunc := func(req *http.Request) string {
+		return req.URL.Path
+	}
+
 	if opts.allowNonRootResources {
 		endpointFunc = GetGRPCEndpoint
 	}

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -63,7 +63,7 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 	}
 
 	if opts.allowNonRootResources {
-		endpointFunc = GetGRPCEndpoint
+		endpointFunc = getGRPCEndpoint
 	}
 
 	return &WrappedGrpcServer{

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -35,6 +35,7 @@ type WrappedGrpcServer struct {
 	originFunc          func(origin string) bool
 	enableWebsockets    bool
 	websocketOriginFunc func(req *http.Request) bool
+	endpointFunc        func(req *http.Request) string
 }
 
 // WrapServer takes a gRPC Server in Go and returns a WrappedGrpcServer that provides gRPC-Web Compatibility.
@@ -56,6 +57,12 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 	if websocketOriginFunc == nil {
 		websocketOriginFunc = defaultWebsocketOriginFunc
 	}
+
+	endpointFunc := func(req *http.Request) string { return req.URL.Path }
+	if opts.allowNonRootResources {
+		endpointFunc = GetGRPCEndpoint
+	}
+
 	return &WrappedGrpcServer{
 		server:              server,
 		opts:                opts,
@@ -63,6 +70,7 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 		originFunc:          opts.originFunc,
 		enableWebsockets:    opts.enableWebsockets,
 		websocketOriginFunc: websocketOriginFunc,
+		endpointFunc:        endpointFunc,
 	}
 }
 
@@ -105,6 +113,7 @@ func (w *WrappedGrpcServer) IsGrpcWebSocketRequest(req *http.Request) bool {
 func (w *WrappedGrpcServer) HandleGrpcWebRequest(resp http.ResponseWriter, req *http.Request) {
 	intReq, isTextFormat := hackIntoNormalGrpcRequest(req)
 	intResp := newGrpcWebResponse(resp, isTextFormat)
+	req.URL.Path = w.endpointFunc(req)
 	w.server.ServeHTTP(intResp, intReq)
 	intResp.finishRequest(req)
 }
@@ -161,6 +170,7 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 		grpclog.Errorf("web socket text format requests not yet supported")
 		return
 	}
+	req.URL.Path = w.endpointFunc(req)
 	w.server.ServeHTTP(respWriter, interceptedRequest)
 }
 
@@ -187,7 +197,7 @@ func (w *WrappedGrpcServer) IsAcceptableGrpcCorsRequest(req *http.Request) bool 
 
 func (w *WrappedGrpcServer) isRequestForRegisteredEndpoint(req *http.Request) bool {
 	registeredEndpoints := ListGRPCResources(w.server)
-	requestedEndpoint := req.URL.Path
+	requestedEndpoint := w.endpointFunc(req)
 	for _, v := range registeredEndpoints {
 		if v == requestedEndpoint {
 			return true

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/textproto"
 	"os"
 	"strconv"
@@ -53,10 +54,11 @@ const (
 
 type GrpcWebWrapperTestSuite struct {
 	suite.Suite
-	httpMajorVersion int
-	listener         net.Listener
-	grpcServer       *grpc.Server
-	wrappedServer    *grpcweb.WrappedGrpcServer
+	httpMajorVersion     int
+	listener             net.Listener
+	grpcServer           *grpc.Server
+	wrappedServer        *grpcweb.WrappedGrpcServer
+	allowNonRootResource bool
 }
 
 func TestHttp2GrpcWebWrapperTestSuite(t *testing.T) {
@@ -65,6 +67,27 @@ func TestHttp2GrpcWebWrapperTestSuite(t *testing.T) {
 
 func TestHttp1GrpcWebWrapperTestSuite(t *testing.T) {
 	suite.Run(t, &GrpcWebWrapperTestSuite{httpMajorVersion: 1})
+}
+
+func TestNonRootResource(t *testing.T) {
+	grpcServer := grpc.NewServer()
+	testproto.RegisterTestServiceServer(grpcServer, &testServiceImpl{})
+	wrappedServer := grpcweb.WrapServer(grpcServer,
+		grpcweb.WithAllowNonRootResource(true),
+		grpcweb.WithOriginFunc(func(origin string) bool {
+			return true
+		}))
+
+	headers := http.Header{}
+	headers.Add("Access-Control-Request-Method", "POST")
+	headers.Add("Access-Control-Request-Headers", "origin, x-something-custom, x-grpc-web, accept")
+	req := httptest.NewRequest("OPTIONS", "http://host/grpc/improbable.grpcweb.test.TestService/Echo", nil)
+	req.Header = headers
+	resp := httptest.NewRecorder()
+	wrappedServer.ServeHTTP(resp, req)
+
+	log.Println(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.Code)
 }
 
 func (s *GrpcWebWrapperTestSuite) SetupTest() {

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -54,11 +54,10 @@ const (
 
 type GrpcWebWrapperTestSuite struct {
 	suite.Suite
-	httpMajorVersion     int
-	listener             net.Listener
-	grpcServer           *grpc.Server
-	wrappedServer        *grpcweb.WrappedGrpcServer
-	allowNonRootResource bool
+	httpMajorVersion int
+	listener         net.Listener
+	grpcServer       *grpc.Server
+	wrappedServer    *grpcweb.WrappedGrpcServer
 }
 
 func TestHttp2GrpcWebWrapperTestSuite(t *testing.T) {

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -85,7 +85,6 @@ func TestNonRootResource(t *testing.T) {
 	resp := httptest.NewRecorder()
 	wrappedServer.ServeHTTP(resp, req)
 
-	log.Println(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.Code)
 }
 


### PR DESCRIPTION
https://github.com/improbable-eng/grpc-web/issues/453

## Changes
Added option `allowNonRootResources`
Added a function `WrappedGrpcServer` that encapsulates the logic of getting the gRPC endpoint from http.Request

## Verification
Added Unit-Tests that ensure the same behavior for the canonical case 
Tested with flag on by default
