### PR TITLE
Remove close notifier methods

### DIFF
--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -66,10 +66,6 @@ func (w *grpcWebResponse) Flush() {
 	}
 }
 
-func (w *grpcWebResponse) CloseNotify() <-chan bool {
-	return w.wrapped.(http.CloseNotifier).CloseNotify()
-}
-
 // prepareHeaders runs all required header copying and transformations to
 // prepare the header of the wrapped response writer.
 func (w *grpcWebResponse) prepareHeaders() {
@@ -160,8 +156,4 @@ func (w *base64ResponseWriter) Flush() {
 	}
 	w.newEncoder()
 	w.wrapped.(http.Flusher).Flush()
-}
-
-func (w *base64ResponseWriter) CloseNotify() <-chan bool {
-	return w.wrapped.(http.CloseNotifier).CloseNotify()
 }

--- a/go/grpcweb/websocket_wrapper.go
+++ b/go/grpcweb/websocket_wrapper.go
@@ -16,20 +16,18 @@ import (
 )
 
 type webSocketResponseWriter struct {
-	writtenHeaders  bool
-	wsConn          *websocket.Conn
-	headers         http.Header
-	flushedHeaders  http.Header
-	closeNotifyChan chan bool
+	writtenHeaders bool
+	wsConn         *websocket.Conn
+	headers        http.Header
+	flushedHeaders http.Header
 }
 
 func newWebSocketResponseWriter(wsConn *websocket.Conn) *webSocketResponseWriter {
 	return &webSocketResponseWriter{
-		writtenHeaders:  false,
-		headers:         make(http.Header),
-		flushedHeaders:  make(http.Header),
-		wsConn:          wsConn,
-		closeNotifyChan: make(chan bool, 1),
+		writtenHeaders: false,
+		headers:        make(http.Header),
+		flushedHeaders: make(http.Header),
+		wsConn:         wsConn,
 	}
 }
 
@@ -88,10 +86,6 @@ func (w *webSocketResponseWriter) FlushTrailers() {
 
 func (w *webSocketResponseWriter) Flush() {
 	// no-op
-}
-
-func (w *webSocketResponseWriter) CloseNotify() <-chan bool {
-	return w.closeNotifyChan
 }
 
 type webSocketWrappedReader struct {


### PR DESCRIPTION
Remove CloseNotifiers. CloseNotify has been deprecated in the standard library since the introduction of the request context. grpc-go removed the use of CloseNotify in march, we should be able to remove this and have users use the request context instead.

Fixes #337


