### PR TITLE
updated example link in docs

### DIFF
--- a/client/grpc-web/README.md
+++ b/client/grpc-web/README.md
@@ -17,7 +17,7 @@ Please see the full [gRPC-Web README](https://github.com/improbable-eng/grpc-web
 
 ## Example Project
 
-There is an [example project available here](https://github.com/improbable-eng/grpc-web/tree/master/example)
+There is an [example project available here](https://github.com/improbable-eng/grpc-web/tree/master/client/grpc-web-react-example)
 
 ## Usage Overview
 * Use [`ts-protoc-gen`](https://www.npmjs.com/package/ts-protoc-gen) with [`protoc`](https://github.com/google/protobuf) to generate `.js` and `.d.ts` files for your request and response classes. `ts-protoc-gen` can also generate gRPC service definitions with the `service=true` argument.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
Swapped old example link to point to the React example project as per #538 
<!-- Enumerate changes you made -->

## Verification
https://github.com/jbpratt78/grpc-web/tree/docs-example-link-fix/client/grpc-web :)
<!-- How you tested it? How do you know it works? -->
