### PR TITLE
Increase websocket timeout to send ping to adapt nginx's websocket proxy

### DIFF
--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -136,6 +136,16 @@ requests - usually to check that the origin is valid.
 The default behaviour is to check that the origin of the request matches the
 host of the request and deny all requests from remote origins.
 
+#### func  WithWebsocketPingInterval
+
+```go
+func WithWebsocketPingInterval(websocketPingInterval time.Duration) Option
+```
+WithWebsocketPingInterval enables websocket keepalive pinging with the
+configured timeout.
+
+The default behaviour is to disable websocket pinging.
+
 #### func  WithWebsockets
 
 ```go
@@ -145,16 +155,6 @@ WithWebsockets allows for handling grpc-web requests of websockets - enabling
 bidirectional requests.
 
 The default behaviour is false, i.e. to disallow websockets
-
-#### func  WithWebsocketPingInterval
-
-```go
-func WithWebsocketPingInterval(websocketPingInterval time.Duration) Option
-```
-WithWebsocketPingInterval enables websocket keepalive pinging with the configured
-timeout.
-
-The default behaviour is to disable websocket pinging.
 
 #### type WrappedGrpcServer
 

--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -146,6 +146,16 @@ bidirectional requests.
 
 The default behaviour is false, i.e. to disallow websockets
 
+#### func  WithWebsocketPingInterval
+
+```go
+func WithWebsocketPingInterval(websocketPingInterval time.Duration) Option
+```
+WithWebsocketPingInterval enables websocket keepalive pinging with the configured
+timeout.
+
+The default behaviour is to disable websocket pinging.
+
 #### type WrappedGrpcServer
 
 ```go

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -19,6 +19,7 @@ type options struct {
 	corsForRegisteredEndpointsOnly bool
 	originFunc                     func(origin string) bool
 	enableWebsockets               bool
+	websocketPingTimeout           uint
 	websocketOriginFunc            func(req *http.Request) bool
 	allowNonRootResources          bool
 }

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -3,7 +3,10 @@
 
 package grpcweb
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 var (
 	defaultOptions = &options{
@@ -19,7 +22,7 @@ type options struct {
 	corsForRegisteredEndpointsOnly bool
 	originFunc                     func(origin string) bool
 	enableWebsockets               bool
-	websocketPingTimeout           uint
+	websocketPingInterval          time.Duration
 	websocketOriginFunc            func(req *http.Request) bool
 	allowNonRootResources          bool
 }
@@ -93,12 +96,12 @@ func WithWebsockets(enableWebsockets bool) Option {
 	}
 }
 
-// WithWebsocketPingTimeout allows for websocket send ping.
+// WithWebsocketPingInterval enables websocket keepalive pinging with the configured timeout (in seconds).
 //
-// The default behaviour is 0, i.e. to disallow websocket ping
-func WithWebsocketPingTimeout(websocketPingTimeout uint) Option {
+// The default behaviour is to disable websocket pinging.
+func WithWebsocketPingInterval(websocketPingInterval time.Duration) Option {
 	return func(o *options) {
-		o.websocketPingTimeout = websocketPingTimeout
+		o.websocketPingInterval = websocketPingInterval
 	}
 }
 

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -96,7 +96,7 @@ func WithWebsockets(enableWebsockets bool) Option {
 	}
 }
 
-// WithWebsocketPingInterval enables websocket keepalive pinging with the configured timeout (in seconds).
+// WithWebsocketPingInterval enables websocket keepalive pinging with the configured timeout.
 //
 // The default behaviour is to disable websocket pinging.
 func WithWebsocketPingInterval(websocketPingInterval time.Duration) Option {

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -93,6 +93,15 @@ func WithWebsockets(enableWebsockets bool) Option {
 	}
 }
 
+// WithWebsocketPingTimeout allows for websocket send ping.
+//
+// The default behaviour is 0, i.e. to disallow websocket ping
+func WithWebsocketPingTimeout(websocketPingTimeout uint) Option {
+	return func(o *options) {
+		o.websocketPingTimeout = websocketPingTimeout
+	}
+}
+
 // WithWebsocketOriginFunc allows for customizing the acceptance of Websocket requests - usually to check that the origin
 // is valid.
 //

--- a/go/grpcweb/websocket_wrapper.go
+++ b/go/grpcweb/websocket_wrapper.go
@@ -45,6 +45,7 @@ func (w *webSocketResponseWriter) ping() {
 		close(dispose)
 		return nil
 	})
+	defer ticker.Stop()
 	for {
 		select {
 		case <-dispose:

--- a/go/grpcweb/websocket_wrapper.go
+++ b/go/grpcweb/websocket_wrapper.go
@@ -10,21 +10,20 @@ import (
 	"net/http"
 	"net/textproto"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/desertbit/timer"
 	"github.com/gorilla/websocket"
 	"golang.org/x/net/http2"
 )
 
 type webSocketResponseWriter struct {
-	writtenHeaders      bool
-	wsConn              *websocket.Conn
-	headers             http.Header
-	flushedHeaders      http.Header
-	timeOutInterval     time.Duration
-	lastMessageTime     time.Time
-	lastMessageTimeLock *sync.Mutex
+	writtenHeaders  bool
+	wsConn          *websocket.Conn
+	headers         http.Header
+	flushedHeaders  http.Header
+	timeOutInterval time.Duration
+	timer           *timer.Timer
 }
 
 func newWebSocketResponseWriter(wsConn *websocket.Conn) *webSocketResponseWriter {
@@ -38,7 +37,7 @@ func newWebSocketResponseWriter(wsConn *websocket.Conn) *webSocketResponseWriter
 
 func (w *webSocketResponseWriter) enablePing(timeOutInterval time.Duration) {
 	w.timeOutInterval = timeOutInterval
-	w.lastMessageTimeLock = &sync.Mutex{}
+	w.timer = timer.NewTimer(w.timeOutInterval)
 	dispose := make(chan bool)
 	w.wsConn.SetCloseHandler(func(code int, text string) error {
 		close(dispose)
@@ -51,23 +50,14 @@ func (w *webSocketResponseWriter) ping(dispose chan bool) {
 	if dispose == nil {
 		return
 	}
-	ticker := time.NewTicker(w.timeOutInterval)
-	defer ticker.Stop()
+	defer w.timer.Stop()
 	for {
 		select {
 		case <-dispose:
 			return
-		case t := <-ticker.C:
-			var sendPing = false
-			w.lastMessageTimeLock.Lock()
-			if t.After(w.lastMessageTime.Add(w.timeOutInterval)) {
-				sendPing = true
-				w.lastMessageTime = time.Now()
-			}
-			w.lastMessageTimeLock.Unlock()
-			if sendPing {
-				w.wsConn.WriteMessage(websocket.PingMessage, []byte{})
-			}
+		case <-w.timer.C:
+			w.timer.Reset(w.timeOutInterval)
+			w.wsConn.WriteMessage(websocket.PingMessage, []byte{})
 		}
 	}
 }
@@ -80,10 +70,8 @@ func (w *webSocketResponseWriter) Write(b []byte) (int, error) {
 	if !w.writtenHeaders {
 		w.WriteHeader(http.StatusOK)
 	}
-	if w.timeOutInterval > time.Second {
-		w.lastMessageTimeLock.Lock()
-		w.lastMessageTime = time.Now()
-		w.lastMessageTimeLock.Unlock()
+	if w.timeOutInterval > time.Second && w.timer != nil {
+		w.timer.Reset(w.timeOutInterval)
 	}
 	return len(b), w.wsConn.WriteMessage(websocket.BinaryMessage, b)
 }

--- a/go/grpcweb/websocket_wrapper.go
+++ b/go/grpcweb/websocket_wrapper.go
@@ -58,7 +58,6 @@ func (w *webSocketResponseWriter) ping() {
 			}
 		}
 	}
-Stop:
 	ticker.Stop()
 }
 

--- a/go/grpcweb/websocket_wrapper.go
+++ b/go/grpcweb/websocket_wrapper.go
@@ -62,12 +62,14 @@ func (w *webSocketResponseWriter) ping() {
 		case <-ticker.C:
 			w.tickerCountLock.Lock()
 			w.tickerCount++
+			var sendPing = false
 			if w.tickerCount >= w.timeOutInterval {
 				w.tickerCount = 0
-				w.tickerCountLock.Unlock()
+				sendPing = true
+			}
+			w.tickerCountLock.Unlock()
+			if sendPing == true {
 				w.wsConn.WriteMessage(websocket.PingMessage, []byte{})
-			} else {
-				w.tickerCountLock.Unlock()
 			}
 		}
 	}

--- a/go/grpcweb/websocket_wrapper.go
+++ b/go/grpcweb/websocket_wrapper.go
@@ -49,7 +49,7 @@ func (w *webSocketResponseWriter) ping() {
 	for {
 		select {
 		case <-dispose:
-			goto Stop
+			return
 		case <-ticker.C:
 			w.tickerCount++
 			if w.tickerCount >= w.timeOutInterval {

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -162,7 +162,9 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 	defer cancelFunc()
 
 	respWriter := newWebSocketResponseWriter(wsConn)
-	respWriter.EnablePing(30)
+	if w.opts.websocketPingTimeout > 0 {
+		respWriter.EnablePing(w.opts.websocketPingTimeout)
+	}
 	wrappedReader := newWebsocketWrappedReader(wsConn, respWriter, cancelFunc)
 
 	req.Body = wrappedReader

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -163,7 +163,7 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 
 	respWriter := newWebSocketResponseWriter(wsConn)
 	if w.opts.websocketPingInterval >= time.Second {
-		respWriter.EnablePing(w.opts.websocketPingInterval)
+		respWriter.enablePing(w.opts.websocketPingInterval)
 	}
 	wrappedReader := newWebsocketWrappedReader(wsConn, respWriter, cancelFunc)
 

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -162,8 +162,8 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 	defer cancelFunc()
 
 	respWriter := newWebSocketResponseWriter(wsConn)
-	if w.opts.websocketPingTimeout > 0 {
-		respWriter.EnablePing(w.opts.websocketPingTimeout)
+	if w.opts.websocketPingInterval >= time.Second {
+		respWriter.EnablePing(w.opts.websocketPingInterval)
 	}
 	wrappedReader := newWebsocketWrappedReader(wsConn, respWriter, cancelFunc)
 

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -162,6 +162,7 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 	defer cancelFunc()
 
 	respWriter := newWebSocketResponseWriter(wsConn)
+	respWriter.EnablePing(30)
 	wrappedReader := newWebsocketWrappedReader(wsConn, respWriter, cancelFunc)
 
 	req.Body = wrappedReader

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -39,6 +39,7 @@ var (
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
 
 	useWebsockets = pflag.Bool("use_websockets", false, "whether to use beta websocket transport layer")
+	websocketPingTimeout = pflag.Int("websocket_ping_timeout_interval", 0, "websocket ping timeout interval, default 0 is disable, take effect when use_websockets = true")
 
 	flagHttpMaxWriteTimeout = pflag.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = pflag.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
@@ -71,6 +72,11 @@ func main() {
 			grpcweb.WithWebsockets(true),
 			grpcweb.WithWebsocketOriginFunc(makeWebsocketOriginFunc(allowedOrigins)),
 		)
+		
+		if *websocketPingTimeout > 0 {
+			logrus.Println("websocket ping timeout %v", *websocketPingTimeout)
+		}
+		grpcweb.WithWebsocketPingTimeout(*websocketPingTimeout),
 	}
 	wrappedGrpc := grpcweb.WrapServer(grpcServer, options...)
 

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -73,7 +73,7 @@ func main() {
 			grpcweb.WithWebsocketOriginFunc(makeWebsocketOriginFunc(allowedOrigins)),
 		)
 		if *websocketPingInterval >= time.Second {
-			logrus.Println(fmt.Sprintf("websocket keepalive pinging enabled, the ping interval is %s, the actual timeout is 1-2 times the interval.", websocketPingInterval.String()))
+			logrus.Infof("websocket keepalive pinging enabled, the ping interval is %s, the actual timeout is 1-2 times the interval.", websocketPingInterval.String())
 		}
 		options = append(
 			options,

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -38,8 +38,8 @@ var (
 	runHttpServer = pflag.Bool("run_http_server", true, "whether to run HTTP server")
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
 
-	useWebsockets = pflag.Bool("use_websockets", false, "whether to use beta websocket transport layer")
-	websocketPingTimeout = pflag.Int("websocket_ping_timeout_interval", 0, "websocket ping timeout interval, default 0 is disable, take effect when use_websockets = true")
+	useWebsockets        = pflag.Bool("use_websockets", false, "whether to use beta websocket transport layer")
+	websocketPingTimeout = pflag.Uint("websocket_ping_timeout_interval", 0, "websocket ping timeout interval, default 0 is disable, take effect when use_websockets = true")
 
 	flagHttpMaxWriteTimeout = pflag.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = pflag.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
@@ -72,11 +72,11 @@ func main() {
 			grpcweb.WithWebsockets(true),
 			grpcweb.WithWebsocketOriginFunc(makeWebsocketOriginFunc(allowedOrigins)),
 		)
-		
+
 		if *websocketPingTimeout > 0 {
-			logrus.Println("websocket ping timeout %v", *websocketPingTimeout)
+			logrus.Println("websocket ping timeout", *websocketPingTimeout)
 		}
-		grpcweb.WithWebsocketPingTimeout(*websocketPingTimeout),
+		grpcweb.WithWebsocketPingTimeout(*websocketPingTimeout)
 	}
 	wrappedGrpc := grpcweb.WrapServer(grpcServer, options...)
 

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -39,7 +39,7 @@ var (
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
 
 	useWebsockets         = pflag.Bool("use_websockets", false, "whether to use beta websocket transport layer")
-	websocketPingInterval = pflag.Duration("websocket_ping_interval", 0, "whether to use websocket keepalive pinging. Only used when using websockets.")
+	websocketPingInterval = pflag.Duration("websocket_ping_interval", 0, "whether to use websocket keepalive pinging. Only used when using websockets. Configured interval must be >= 1s. The actual timeout is 1-2 times the interval.")
 
 	flagHttpMaxWriteTimeout = pflag.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = pflag.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
@@ -73,7 +73,7 @@ func main() {
 			grpcweb.WithWebsocketOriginFunc(makeWebsocketOriginFunc(allowedOrigins)),
 		)
 		if *websocketPingInterval >= time.Second {
-			logrus.Println(fmt.Sprintf("enables websocket keepalive pinging, the timeout interval is %f seconds", websocketPingInterval.Seconds()))
+			logrus.Println(fmt.Sprintf("websocket keepalive pinging enabled, the ping interval is %s, the actual timeout is 1-2 times the interval.", websocketPingInterval.String()))
 		}
 		options = append(
 			options,

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -39,7 +39,7 @@ var (
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
 
 	useWebsockets         = pflag.Bool("use_websockets", false, "whether to use beta websocket transport layer")
-	websocketPingInterval = pflag.Duration("websocket_ping_interval", 0, "whether to use websocket keepalive pinging. Only used when using websockets. Configured interval must be >= 1s. The actual timeout is 1-2 times the interval.")
+	websocketPingInterval = pflag.Duration("websocket_ping_interval", 0, "whether to use websocket keepalive pinging. Only used when using websockets. Configured interval must be >= 1s.")
 
 	flagHttpMaxWriteTimeout = pflag.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = pflag.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
@@ -73,7 +73,7 @@ func main() {
 			grpcweb.WithWebsocketOriginFunc(makeWebsocketOriginFunc(allowedOrigins)),
 		)
 		if *websocketPingInterval >= time.Second {
-			logrus.Infof("websocket keepalive pinging enabled, the ping interval is %s, the actual timeout is 1-2 times the interval.", websocketPingInterval.String())
+			logrus.Infof("websocket keepalive pinging enabled, the timeout interval is %s", websocketPingInterval.String())
 		}
 		options = append(
 			options,


### PR DESCRIPTION
当我尝试用nginx代理grpc-web中的websocket时，由于nginx有检测断开机制，导致超过60秒没有推送消息会断开。
nginx官网的解释时这样的：http://nginx.org/en/docs/http/websocket.html

> When I try to use nginx to proxy the websocket in grpc-web, since nginx has a detection disconnection mechanism, no push message will be disconnected for more than 60 seconds.
Nginx official website explains this

## Changes

根据nginx的官网说明，我在服务器的推送上增加了超时发送Ping的功能。

> According to the official website of nginx, I added the function of timeout to send Ping on the push of the server.

## Verification

经过修改，已经可以实现nginx代理websocket并且不自动断开了。

> After modification, the nginx proxy websocket can be implemented and not automatically disconnected.

Sorry, My English is not good, so I did not use English instructions.

(Translations courtesy of google translate - @johanbrandhorst)