### PR TITLE
Ws request headers

### DIFF
--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -34,6 +34,7 @@ var (
 
 	flagAllowAllOrigins = pflag.Bool("allow_all_origins", false, "allow requests from any origin.")
 	flagAllowedOrigins  = pflag.StringSlice("allowed_origins", nil, "comma-separated list of origin URLs which are allowed to make cross-origin requests.")
+	flagAllowedHeaders  = pflag.StringSlice("allowed_headers", []string{}, "comma-separated list of headers which are allowed to propagate to the gRPC backend.")
 
 	runHttpServer = pflag.Bool("run_http_server", true, "whether to run HTTP server")
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
@@ -80,6 +81,14 @@ func main() {
 			grpcweb.WithWebsocketPingInterval(*websocketPingInterval),
 		)
 	}
+
+	if len(*flagAllowedHeaders) > 0 {
+		options = append(
+			options,
+			grpcweb.WithAllowedRequestHeaders(*flagAllowedHeaders),
+		)
+	}
+
 	wrappedGrpc := grpcweb.WrapServer(grpcServer, options...)
 
 	if !*runHttpServer && !*runTlsServer {

--- a/integration_test/go/testserver/testserver.go
+++ b/integration_test/go/testserver/testserver.go
@@ -165,11 +165,11 @@ func (s *testSrv) PingError(ctx context.Context, ping *testproto.PingRequest) (*
 	if ping.GetSendTrailers() {
 		grpc.SetTrailer(ctx, metadata.Pairs("TrailerTestKey1", "ServerValue1", "TrailerTestKey2", "ServerValue2"))
 	}
+	var msg = "💣"
 	if ping.FailureType == testproto.PingRequest_CODE {
-		return nil, grpc.Errorf(codes.Code(ping.ErrorCodeReturned), "Intentionally returning error for PingError")
-	} else {
-		return nil, grpc.Errorf(codes.Code(ping.ErrorCodeReturned), "💣")
+		msg = "Intentionally returning error for PingError"
 	}
+	return nil, grpc.Errorf(codes.Code(ping.ErrorCodeReturned), msg)
 }
 
 func (s *testSrv) ContinueStream(ctx context.Context, req *testproto.ContinueStreamRequest) (*google_protobuf.Empty, error) {


### PR DESCRIPTION
A flag for grpcWebProxy to allow to propagate some request headers

## Changes

- subj.
- fixed grpcweb.WrappedGrpcServer header propagation to gRPC in case of using websockets
-  fixed small test warning

## Verification

App compiles and works fine in production.
