### PR TITLE
Check that there aren't any unknown command line arguments

### DIFF
--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -48,6 +48,14 @@ var (
 
 func main() {
 	pflag.Parse()
+	if len(pflag.Args()) != 0 {
+		for _, flag := range pflag.Args() {
+			if flag == "true" || flag == "false" {
+				logrus.Fatal("Boolean flags should be set using --flag=false, --flag=true or --flag (which is short for --flag=true). You cannot use --flag true or --flag false.")
+			}
+		}
+		logrus.Fatal("Unknown argument: " + flag)
+	}
 
 	logrus.SetOutput(os.Stdout)
 	logEntry := logrus.NewEntry(logrus.StandardLogger())

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -48,11 +48,9 @@ var (
 
 func main() {
 	pflag.Parse()
-	if len(pflag.Args()) != 0 {
-		for _, flag := range pflag.Args() {
-			if flag == "true" || flag == "false" {
-				logrus.Fatal("Boolean flags should be set using --flag=false, --flag=true or --flag (which is short for --flag=true). You cannot use --flag true or --flag false.")
-			}
+	for _, flag := range pflag.Args() {
+		if flag == "true" || flag == "false" {
+			logrus.Fatal("Boolean flags should be set using --flag=false, --flag=true or --flag (which is short for --flag=true). You cannot use --flag true or --flag false.")
 		}
 		logrus.Fatal("Unknown argument: " + flag)
 	}


### PR DESCRIPTION
See #564

## Changes

* Check that there are no unknown command line arguments.

## Verification

I haven't been able to test this because I get  a compilation error when building:

```
# github.com/grpc-ecosystem/go-grpc-prometheus
/Users/me/go/src/github.com/grpc-ecosystem/go-grpc-prometheus/client_reporter.go:51:29: cannot use prometheus.NewTimer(hist) (type *prometheus.Timer) as type timer in return argument:
        *prometheus.Timer does not implement timer (wrong type for ObserveDuration method)
                have ObserveDuration()
                want ObserveDuration() time.Duration
/Users/me/go/src/github.com/grpc-ecosystem/go-grpc-prometheus/client_reporter.go:64:29: cannot use prometheus.NewTimer(hist) (type *prometheus.Timer) as type timer in return argument:
        *prometheus.Timer does not implement timer (wrong type for ObserveDuration method)
                have ObserveDuration()
                want ObserveDuration() time.Duration
```