### PR TITLE
Remove connection header from grpcwebproxy

### DIFF
--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -151,6 +151,7 @@ func buildGrpcProxyServer(logger *logrus.Entry) *grpc.Server {
 		md, _ := metadata.FromIncomingContext(ctx)
 		outCtx, _ := context.WithCancel(ctx)
 		mdCopy := md.Copy()
+		delete(mdCopy, "user-agent")
 		delete(mdCopy, "connection")
 		outCtx = metadata.NewOutgoingContext(outCtx, mdCopy)
 		return outCtx, backendConn, nil

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -152,6 +152,8 @@ func buildGrpcProxyServer(logger *logrus.Entry) *grpc.Server {
 		outCtx, _ := context.WithCancel(ctx)
 		mdCopy := md.Copy()
 		delete(mdCopy, "user-agent")
+		// If this header is present in the request from the web client,
+		// the actual connection to the backend will not be established.
 		delete(mdCopy, "connection")
 		outCtx = metadata.NewOutgoingContext(outCtx, mdCopy)
 		return outCtx, backendConn, nil

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -154,6 +154,7 @@ func buildGrpcProxyServer(logger *logrus.Entry) *grpc.Server {
 		delete(mdCopy, "user-agent")
 		// If this header is present in the request from the web client,
 		// the actual connection to the backend will not be established.
+		// https://github.com/improbable-eng/grpc-web/issues/568
 		delete(mdCopy, "connection")
 		outCtx = metadata.NewOutgoingContext(outCtx, mdCopy)
 		return outCtx, backendConn, nil

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -151,7 +151,7 @@ func buildGrpcProxyServer(logger *logrus.Entry) *grpc.Server {
 		md, _ := metadata.FromIncomingContext(ctx)
 		outCtx, _ := context.WithCancel(ctx)
 		mdCopy := md.Copy()
-		delete(mdCopy, "user-agent")
+		delete(mdCopy, "connection")
 		outCtx = metadata.NewOutgoingContext(outCtx, mdCopy)
 		return outCtx, backendConn, nil
 	}


### PR DESCRIPTION
This PR fixes the issue expressed in https://github.com/improbable-eng/grpc-web/issues/568. Basically, when you are sending a gRPC request from a web client through the proxy, multiple headers are added of which `connection` is denying the actual connection to be established.

Error message with the `connection` header present:
```
INFO[0000] listening for http on: [::]:8080             
INFO[0000] pickfirstBalancer: HandleSubConnStateChange: 0xc00015e200, READY  system=system
INFO[0075] transport: loopyWriter.run returning. connection error: desc = "transport is closing"  system=system
INFO[0075] pickfirstBalancer: HandleSubConnStateChange: 0xc00015e200, TRANSIENT_FAILURE  system=system
INFO[0075] pickfirstBalancer: HandleSubConnStateChange: 0xc00015e200, CONNECTING  system=system
WARN[0075] finished streaming call with code Unavailable  error="rpc error: code = Unavailable desc = transport is closing" grpc.code=Unavailable grpc.method=Method grpc.service=namespace.Service grpc.start_time="2019-10-28T11:56:35Z" grpc.time_ms=1052.424 span.kind=server system=grpc
```