### PR TITLE
[client] node-http-transport fix deprecation

### DIFF
--- a/client/grpc-web-node-http-transport/src/index.ts
+++ b/client/grpc-web-node-http-transport/src/index.ts
@@ -101,7 +101,7 @@ function toArrayBuffer(buf: Buffer): Uint8Array {
 }
 
 function toBuffer(ab: Uint8Array): Buffer {
-  const buf = new Buffer(ab.byteLength);
+  const buf = Buffer.alloc(ab.byteLength);
   for (let i = 0; i < buf.length; i++) {
     buf[i] = ab[i];
   }


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Fixes wanring: [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues.

<!-- Enumerate changes you made -->

## Verification


<!-- How you tested it? How do you know it works? -->
