### PR TITLE
handle websocket closed event

### DIFF
--- a/go/grpcweb/websocket_wrapper.go
+++ b/go/grpcweb/websocket_wrapper.go
@@ -181,7 +181,7 @@ func (w *webSocketWrappedReader) Read(p []byte) (int, error) {
 
 	// If the frame consists of only a single byte of value 1 then this indicates the client has finished sending
 	if len(framePayload) == 1 && framePayload[0] == 1 {
-		return 0, io.EOF
+		return 0, nil
 	}
 
 	// If the frame is somehow empty then just return the error


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Change the error returned by webSocketWrappedReader.Read when the frame is a single byte of value 1 (which indicates the client has finished sending) from io.EOF to nil.
Rationale:
When a stream request is made using a websocket, `handleWebSocket` (wrapper.go)  is called. This function run server.ServeHTTP to proxy the stream. Aside of forwarding messages from the server to the client, it reads messages coming from the websocket using the webSocketWrappedReader.Read method (websocket_wrapper.go), but this method was returning an io.EOF error when a end-of-message frame was received.
The fact is that it is the grpc.Server reads on the websocket until an error is returned by the read. 
So when the wrapper was reading the end of the first message received by the client (the initial stream request), it was returning EOF and the grpc.ServerHTTP reader routine was stopped.

Then nobody was reading on the websocket after the first message was sent from the client, so when the closed event was sent from the frontend on a refresh or tab closed i.e, it could not detect it and close the entire stream.

## Verification
I tested with my project which open infinite streams and I runned the go test, but more test could be done.