### PR TITLE
Add "WrapHandler" function and "WithEndpointsFunc" option

### DIFF
--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -191,7 +191,7 @@ WrapHandler takes a http.Handler (such as a http.Mux) and returns a
 *WrappedGrpcServer that provides gRPC-Web Compatibility.
 
 This behaves nearly identically to WrapServer except when the
-`corsForRegisteredEndpointsOnly` setting is true. Then a `WithEndpointsFunc`
+WithCorsForRegisteredEndpointsOnly setting is true. Then a WithEndpointsFunc
 option must be provided or all CORS requests will NOT be handled.
 
 #### func  WrapServer

--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -182,6 +182,7 @@ type WrappedGrpcServer struct {
 }
 ```
 
+
 #### func  WrapHandler
 
 ```go

--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -108,6 +108,25 @@ endpoints (e.g. for proxying).
 The default behaviour is `true`, i.e. only allows CORS requests for registered
 endpoints.
 
+#### func  WithEndpointsFunc
+
+```go
+func WithEndpointsFunc(endpointsFunc func() []string) Option
+```
+WithEndpointsFunc allows for providing a custom function that provides all
+supported endpoints for use when the when `WithCorsForRegisteredEndpoints`
+option` is not set to false (i.e. the default state).
+
+When wrapping a http.Handler with `WrapHttpHandler`, failing to specify the
+`WithEndpointsFunc` option will cause all CORS requests to result in a 403 error
+for websocket requests (if websockets are enabled) or be passed to the handler
+http.Handler or grpc.Server backend (i.e. as if it wasn't wrapped).
+
+When wrapping grpc.Server with `WrapGrpcServer`, registered endpoints will be
+automatically detected, however if this `WithEndpointsFunc` option is specified,
+the server will not be queried for its endpoints and this function will be
+called instead.
+
 #### func  WithOriginFunc
 
 ```go
@@ -163,13 +182,24 @@ type WrappedGrpcServer struct {
 }
 ```
 
+#### func  WrapHandler
+
+```go
+func WrapHandler(handler http.Handler, options ...Option) *WrappedGrpcServer
+```
+WrapHandler takes a http.Handler (such as a http.Mux) and returns a
+*WrappedGrpcServer that provides gRPC-Web Compatibility.
+
+This behaves nearly identically to WrapServer except when the
+`corsForRegisteredEndpointsOnly` setting is true. Then a `WithEndpointsFunc`
+option must be provided or all CORS requests will NOT be handled.
 
 #### func  WrapServer
 
 ```go
 func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer
 ```
-WrapServer takes a gRPC Server in Go and returns a WrappedGrpcServer that
+WrapServer takes a gRPC Server in Go and returns a *WrappedGrpcServer that
 provides gRPC-Web Compatibility.
 
 The internal implementation fakes out a http.Request that carries standard gRPC,

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -25,6 +25,7 @@ type options struct {
 	websocketPingInterval          time.Duration
 	websocketOriginFunc            func(req *http.Request) bool
 	allowNonRootResources          bool
+	endpointsFunc                  *func() []string
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -63,6 +64,22 @@ func WithOriginFunc(originFunc func(origin string) bool) Option {
 func WithCorsForRegisteredEndpointsOnly(onlyRegistered bool) Option {
 	return func(o *options) {
 		o.corsForRegisteredEndpointsOnly = onlyRegistered
+	}
+}
+
+// WithEndpointsFuncs allows for providing a custom function that provides all supported endpoints for use when the
+// when `WithCorsForRegisteredEndPoints option` is not set to false (i.e. the default state).
+//
+// When wrapping a http.Handler with `WrapHttpHandler`, failing to specify the `WithHandpointsFunc` option will cause
+// all CORS requests to result in a 403 error for websocket requests (if websockets are enabled) or be passed to the
+// handler http.Handler or grpc.Server backend (i.e. as if it wasn't wrapped)
+//
+// When wrapping grpc.Server with `WrapGrpcServer, registered endpoints will be automatically detected however if this
+// `WithEndpointsFunc` option is specified, the server will not be queried for its endpoints and this function will
+// be called instead
+func WithEndpointsFunc(endpointsFunc func() []string) Option {
+	return func(o *options) {
+		o.endpointsFunc = &endpointsFunc
 	}
 }
 

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -67,16 +67,16 @@ func WithCorsForRegisteredEndpointsOnly(onlyRegistered bool) Option {
 	}
 }
 
-// WithEndpointsFuncs allows for providing a custom function that provides all supported endpoints for use when the
-// when `WithCorsForRegisteredEndPoints option` is not set to false (i.e. the default state).
+// WithEndpointsFunc allows for providing a custom function that provides all supported endpoints for use when the
+// when `WithCorsForRegisteredEndpoints` option` is not set to false (i.e. the default state).
 //
-// When wrapping a http.Handler with `WrapHttpHandler`, failing to specify the `WithHandpointsFunc` option will cause
+// When wrapping a http.Handler with `WrapHttpHandler`, failing to specify the `WithEndpointsFunc` option will cause
 // all CORS requests to result in a 403 error for websocket requests (if websockets are enabled) or be passed to the
-// handler http.Handler or grpc.Server backend (i.e. as if it wasn't wrapped)
+// handler http.Handler or grpc.Server backend (i.e. as if it wasn't wrapped).
 //
-// When wrapping grpc.Server with `WrapGrpcServer, registered endpoints will be automatically detected however if this
+// When wrapping grpc.Server with `WrapGrpcServer`, registered endpoints will be automatically detected, however if this
 // `WithEndpointsFunc` option is specified, the server will not be queried for its endpoints and this function will
-// be called instead
+// be called instead.
 func WithEndpointsFunc(endpointsFunc func() []string) Option {
 	return func(o *options) {
 		o.endpointsFunc = &endpointsFunc

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -40,7 +40,7 @@ type WrappedGrpcServer struct {
 	endpointsFunc       func() []string
 }
 
-// WrapServer takes a gRPC Server in Go and returns a WrappedGrpcServer that provides gRPC-Web Compatibility.
+// WrapServer takes a gRPC Server in Go and returns a *WrappedGrpcServer that provides gRPC-Web Compatibility.
 //
 // The internal implementation fakes out a http.Request that carries standard gRPC, and performs the remapping inside
 // http.ResponseWriter, i.e. mostly the re-encoding of Trailers (that carry gRPC status).
@@ -55,7 +55,7 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 // WrapHandler takes a http.Handler (such as a http.Mux) and returns a WrappedHttpHandler that provides gRPC-Web Compatibility.
 //
 // This behaves nearly identically to WrapServer except when the `corsForRegisteredEndpointsOnly` setting is true.
-// Then a `WithEndpointFilter` option must be provided or all CORs requests will NOT be handled
+// Then a `WithEndpointsFunc` option must be provided or all CORS requests will NOT be handled
 func WrapHandler(handler http.Handler, options ...Option) *WrappedGrpcServer {
 	return wrapGrpc(options, handler, func() [] string {
 		return []string{}

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -52,10 +52,11 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 	})
 }
 
-// WrapHandler takes a http.Handler (such as a http.Mux) and returns a WrappedHttpHandler that provides gRPC-Web Compatibility.
+// WrapHandler takes a http.Handler (such as a http.Mux) and returns a *WrappedGrpcServer that provides gRPC-Web
+// Compatibility.
 //
 // This behaves nearly identically to WrapServer except when the `corsForRegisteredEndpointsOnly` setting is true.
-// Then a `WithEndpointsFunc` option must be provided or all CORS requests will NOT be handled
+// Then a `WithEndpointsFunc` option must be provided or all CORS requests will NOT be handled.
 func WrapHandler(handler http.Handler, options ...Option) *WrappedGrpcServer {
 	return wrapGrpc(options, handler, func() [] string {
 		return []string{}

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -55,8 +55,8 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 // WrapHandler takes a http.Handler (such as a http.Mux) and returns a *WrappedGrpcServer that provides gRPC-Web
 // Compatibility.
 //
-// This behaves nearly identically to WrapServer except when the `corsForRegisteredEndpointsOnly` setting is true.
-// Then a `WithEndpointsFunc` option must be provided or all CORS requests will NOT be handled.
+// This behaves nearly identically to WrapServer except when the WithCorsForRegisteredEndpointsOnly setting is true.
+// Then a WithEndpointsFunc option must be provided or all CORS requests will NOT be handled.
 func WrapHandler(handler http.Handler, options ...Option) *WrappedGrpcServer {
 	return wrapGrpc(options, handler, func() [] string {
 		return []string{}

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -29,7 +29,7 @@ const grpcWebContentType = "application/grpc-web"
 const grpcWebTextContentType = "application/grpc-web-text"
 
 type WrappedGrpcServer struct {
-	server              *grpc.Server
+	handler             http.Handler
 	opts                *options
 	corsWrapper         *cors.Cors
 	originFunc          func(origin string) bool
@@ -37,6 +37,7 @@ type WrappedGrpcServer struct {
 	websocketOriginFunc func(req *http.Request) bool
 	allowedHeaders      []string
 	endpointFunc        func(req *http.Request) string
+	endpointsFunc       func() []string
 }
 
 // WrapServer takes a gRPC Server in Go and returns a WrappedGrpcServer that provides gRPC-Web Compatibility.
@@ -46,6 +47,22 @@ type WrappedGrpcServer struct {
 //
 // You can control the behaviour of the wrapper (e.g. modifying CORS behaviour) using `With*` options.
 func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
+	return wrapGrpc(options, server, func() [] string {
+		return ListGRPCResources(server)
+	})
+}
+
+// WrapHandler takes a http.Handler (such as a http.Mux) and returns a WrappedHttpHandler that provides gRPC-Web Compatibility.
+//
+// This behaves nearly identically to WrapServer except when the `corsForRegisteredEndpointsOnly` setting is true.
+// Then a `WithEndpointFilter` option must be provided or all CORs requests will NOT be handled
+func WrapHandler(handler http.Handler, options ...Option) *WrappedGrpcServer {
+	return wrapGrpc(options, handler, func() [] string {
+		return []string{}
+	})
+}
+
+func wrapGrpc(options []Option, handler http.Handler, endpointsFunc func() []string) *WrappedGrpcServer {
 	opts := evaluateOptions(options)
 	allowedHeaders := append(opts.allowedRequestHeaders, internalRequestHeadersWhitelist...)
 	corsWrapper := cors.New(cors.Options{
@@ -68,8 +85,12 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 		endpointFunc = getGRPCEndpoint
 	}
 
+	if opts.endpointsFunc != nil {
+		endpointsFunc = *opts.endpointsFunc
+	}
+
 	return &WrappedGrpcServer{
-		server:              server,
+		handler:             handler,
 		opts:                opts,
 		corsWrapper:         corsWrapper,
 		originFunc:          opts.originFunc,
@@ -77,6 +98,7 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 		websocketOriginFunc: websocketOriginFunc,
 		allowedHeaders:      allowedHeaders,
 		endpointFunc:        endpointFunc,
+		endpointsFunc:       endpointsFunc,
 	}
 }
 
@@ -96,7 +118,7 @@ func (w *WrappedGrpcServer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 			}
 		}
 		resp.WriteHeader(403)
-		resp.Write(make([]byte, 0))
+		_, _ = resp.Write(make([]byte, 0))
 		return
 	}
 
@@ -104,7 +126,7 @@ func (w *WrappedGrpcServer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 		w.corsWrapper.Handler(http.HandlerFunc(w.HandleGrpcWebRequest)).ServeHTTP(resp, req)
 		return
 	}
-	w.server.ServeHTTP(resp, req)
+	w.handler.ServeHTTP(resp, req)
 }
 
 // IsGrpcWebSocketRequest determines if a request is a gRPC-Web request by checking that the "Sec-Websocket-Protocol"
@@ -120,7 +142,7 @@ func (w *WrappedGrpcServer) HandleGrpcWebRequest(resp http.ResponseWriter, req *
 	intReq, isTextFormat := hackIntoNormalGrpcRequest(req)
 	intResp := newGrpcWebResponse(resp, isTextFormat)
 	req.URL.Path = w.endpointFunc(req)
-	w.server.ServeHTTP(intResp, intReq)
+	w.handler.ServeHTTP(intResp, intReq)
 	intResp.finishRequest(req)
 }
 
@@ -135,7 +157,7 @@ var websocketUpgrader = websocket.Upgrader{
 // compatibility layer to transform it to a standard gRPC request for the wrapped gRPC server and transforms the
 // response to comply with the gRPC-Web protocol.
 func (w *WrappedGrpcServer) HandleGrpcWebsocketRequest(resp http.ResponseWriter, req *http.Request) {
-	conn, err := websocketUpgrader.Upgrade(resp, req, nil)
+	wsConn, err := websocketUpgrader.Upgrade(resp, req, nil)
 	if err != nil {
 		grpclog.Errorf("Unable to upgrade websocket request: %v", err)
 		return
@@ -146,10 +168,7 @@ func (w *WrappedGrpcServer) HandleGrpcWebsocketRequest(resp http.ResponseWriter,
 			headers[name] = values
 		}
 	}
-	w.handleWebSocket(conn, req, headers)
-}
 
-func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Request, headers http.Header) {
 	messageType, readBytes, err := wsConn.ReadMessage()
 	if err != nil {
 		grpclog.Errorf("Unable to read first websocket message: %v", err)
@@ -186,10 +205,9 @@ func (w *WrappedGrpcServer) handleWebSocket(wsConn *websocket.Conn, req *http.Re
 	interceptedRequest, isTextFormat := hackIntoNormalGrpcRequest(req.WithContext(ctx))
 	if isTextFormat {
 		grpclog.Errorf("web socket text format requests not yet supported")
-		return
 	}
 	req.URL.Path = w.endpointFunc(req)
-	w.server.ServeHTTP(respWriter, interceptedRequest)
+	w.handler.ServeHTTP(respWriter, interceptedRequest)
 }
 
 // IsGrpcWebRequest determines if a request is a gRPC-Web request by checking that the "content-type" is
@@ -214,7 +232,7 @@ func (w *WrappedGrpcServer) IsAcceptableGrpcCorsRequest(req *http.Request) bool 
 }
 
 func (w *WrappedGrpcServer) isRequestForRegisteredEndpoint(req *http.Request) bool {
-	registeredEndpoints := ListGRPCResources(w.server)
+	registeredEndpoints := w.endpointsFunc()
 	requestedEndpoint := w.endpointFunc(req)
 	for _, v := range registeredEndpoints {
 		if v == requestedEndpoint {

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -47,7 +47,7 @@ type WrappedGrpcServer struct {
 //
 // You can control the behaviour of the wrapper (e.g. modifying CORS behaviour) using `With*` options.
 func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
-	return wrapGrpc(options, server, func() [] string {
+	return wrapGrpc(options, server, func() []string {
 		return ListGRPCResources(server)
 	})
 }
@@ -58,7 +58,7 @@ func WrapServer(server *grpc.Server, options ...Option) *WrappedGrpcServer {
 // This behaves nearly identically to WrapServer except when the WithCorsForRegisteredEndpointsOnly setting is true.
 // Then a WithEndpointsFunc option must be provided or all CORS requests will NOT be handled.
 func WrapHandler(handler http.Handler, options ...Option) *WrappedGrpcServer {
-	return wrapGrpc(options, handler, func() [] string {
+	return wrapGrpc(options, handler, func() []string {
 		return []string{}
 	})
 }


### PR DESCRIPTION
In some applications that handle GRPC requests (the REST grpc-gateway project is a good example), they use the http.ServeMux to serve requests.

In these cases, it would be helpful for the "WrapServer" function to allow passing a "http.Handler" so that grpcweb can wrap the http handler.  The only functionality grpcweb uses of the grpc.Server itself is to list the endpoints for use in determining if the request is for a registered endpoint.

This PR adds the "WrapHandler" function and a new "WithEndpointsFunc" option that allows passing a http.Handler and an optional WithEndpointsFunc option that allows for a custom function to return the registered endpoints of the service.  This is used primarily for the CORS preflight request handling.