### PR TITLE
fix: do not return EOF error when clent finished to sends the request

### DIFF
--- a/go/grpcweb/websocket_wrapper.go
+++ b/go/grpcweb/websocket_wrapper.go
@@ -181,7 +181,7 @@ func (w *webSocketWrappedReader) Read(p []byte) (int, error) {
 
 	// If the frame consists of only a single byte of value 1 then this indicates the client has finished sending
 	if len(framePayload) == 1 && framePayload[0] == 1 {
-		return 0, io.EOF
+		return 0, nil
 	}
 
 	// If the frame is somehow empty then just return the error


### PR DESCRIPTION
originaly from https://github.com/improbable-eng/grpc-web/pull/616

Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

Same rationale as originally proposed in:
https://github.com/improbable-eng/grpc-web/pull/616

## Changes

Same fix as originally proposed in:
https://github.com/improbable-eng/grpc-web/pull/616

## Verification

Going through the Travis CI script, all tests now pass locally for Safari, Firefox, and Chrome. There were some issues with CA certs at first, but this appears to be handled by Karma in CI. Was unable to test older versions of Firefox locally, so hopefully the CI tests pass now, otherwise, further investigation will be required.
