### PR TITLE
Check self is defined to works in nodejs environment.

### DIFF
--- a/client/grpc-web/src/transports/http/fetch.ts
+++ b/client/grpc-web/src/transports/http/fetch.ts
@@ -25,7 +25,7 @@ class Fetch implements Transport {
   init: FetchTransportInit;
   reader: ReadableStreamReader;
   metadata: Metadata;
-  controller: AbortController | undefined = self && (self as any).AbortController && new AbortController();
+  controller: AbortController | undefined = typeof self !== "undefined" && (self as any).AbortController && new AbortController();
 
   constructor(transportOptions: TransportOptions, init: FetchTransportInit) {
     this.options = transportOptions;

--- a/client/grpc-web/src/transports/http/fetch.ts
+++ b/client/grpc-web/src/transports/http/fetch.ts
@@ -25,7 +25,7 @@ class Fetch implements Transport {
   init: FetchTransportInit;
   reader: ReadableStreamReader;
   metadata: Metadata;
-  controller: AbortController | undefined = (self as any).AbortController && new AbortController();
+  controller: AbortController | undefined = self && (self as any).AbortController && new AbortController();
 
   constructor(transportOptions: TransportOptions, init: FetchTransportInit) {
     this.options = transportOptions;


### PR DESCRIPTION
## Changes
In nodejs environment (in my case server side rendering nextjs server), following error occurs
```
ReferenceError: self is not defined
    at new e (/Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:13009)
    at /Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:12923
    at /Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:12934
    at o (/Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:12036)
    at Object.t.makeDefaultTransport (/Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:12129)
    at e.createTransport (/Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:2565)
    at new e (/Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:2120)
    at Object.t.client (/Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:1828)
    at Object.t.unary (/Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/@improbable-eng/grpc-web/dist/grpc-web-client.js:1:24757)
    at CatClient.getMyCat (webpack-internal:///./pb/test_pb_service.js:34:21)
    at data (webpack-internal:///./pages/users/[id].tsx:68:12)
    at new Promise (<anonymous>)
    at fetchMyCat (webpack-internal:///./pages/users/[id].tsx:67:22)
    at getStaticProps (webpack-internal:///./pages/users/[id].tsx:46:24)
    at renderToHTML (/Users/takeshitsukamoto/go/src/github.com/chotchy-inc/next/web/node_modules/next/dist/next-server/server/render.js:27:115)
```

Added `self` check to also work in nodejs.

## Verification
Test it on nodejs and check if the above error doesn't appear.