### PR TITLE
grpcweb: Websockets test should use case-insensitive header compare

### DIFF
--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -133,7 +133,7 @@ func (w *WrappedGrpcServer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 // IsGrpcWebSocketRequest determines if a request is a gRPC-Web request by checking that the "Sec-Websocket-Protocol"
 // header value is "grpc-websockets"
 func (w *WrappedGrpcServer) IsGrpcWebSocketRequest(req *http.Request) bool {
-	return req.Header.Get("Upgrade") == "websocket" && req.Header.Get("Sec-Websocket-Protocol") == "grpc-websockets"
+	return strings.ToLower(req.Header.Get("Upgrade")) == "websocket" && strings.ToLower(req.Header.Get("Sec-Websocket-Protocol")) == "grpc-websockets"
 }
 
 // HandleGrpcWebRequest takes a HTTP request that is assumed to be a gRPC-Web request and wraps it with a compatibility


### PR DESCRIPTION
When checking if a request is a websocket request, the `Upgrade` header is checked to see if it contains the text `websocket`. However, IE11 sends the text `Websocket` (capital W).  The comparison should be made case-insensitive to support browsers that send non-standard requests.
Yes, I know IE11 is going away, but this browser is still used by the WinForms WebBrowser control, for those poor souls that must continue deal with it.

## Changes

Convert the header values to lower case before comparing in `IsGrpcWebSocketRequest`.

## Verification

Tried a small example manually in IE11 and latest Chrome (Win7 64bit).
I couldn't get the tests to run locally.
