### PR TITLE
Allow non-master branches to be built on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ env:
 cache:
   directories:
     - node_modules
-branches:
-  only:
-  - master
 before_install:
   - sudo apt-get install unzip
 install:


### PR DESCRIPTION
To enable a workaround for #740 that would be to:
* Manually push the branch of the fork being raised in PR to a branch on this repo
* Manually trigger the build of the branch on this repo in Travis CI
* Link the results of the CI run to the original PR