### PR TITLE
Upgrade go test version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.11"
+  - "1.15.2"
 go_import_path: github.com/improbable-eng/grpc-web
 addons:
   hosts:

--- a/go/lint.sh
+++ b/go/lint.sh
@@ -43,13 +43,8 @@ function goimports_all {
 
 function govet_all {
     echo "- Running govet"
-    ret=0
-    for i in $(print_real_go_files); do
-        output=$(go tool vet -all=true -tests=false ${i})
-        ret=$(($ret | $?))
-        echo -n ${output}
-    done;
-    if [[ $ret -ne 0 ]]; then
+    go vet -all=true -tests=false ./...
+    if [[ $? -ne 0 ]]; then
         echo "ERROR: govet errors detected, please commit/fix them."
         exit 1
     fi

--- a/lint-all.sh
+++ b/lint-all.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 echo "Linting go sources"
 cd go && . ./lint.sh && cd ..
 


### PR DESCRIPTION
## Changes

* Updated go version used in tests to `1.15.2` (latest as of PR creation)
* Updated `go vet` usage that has changed since `1.11`

## Verification

* Ran in CI


This is part of a wider effort to bring the project up-to-date before actioning some issues.