### PR TITLE
Drop proxy-connection header

### DIFF
--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -156,6 +156,7 @@ func buildGrpcProxyServer(logger *logrus.Entry) *grpc.Server {
 		// the actual connection to the backend will not be established.
 		// https://github.com/improbable-eng/grpc-web/issues/568
 		delete(mdCopy, "connection")
+		delete(mdCopy, "proxy-connection")
 		outCtx = metadata.NewOutgoingContext(outCtx, mdCopy)
 		return outCtx, backendConn, nil
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
Drop the 'Proxy-Connection' header from the grpcwebproxy.
This is related to issue #588, when testing ui with Cypress, instead adding the connection header, the {'proxy-connection': 'keep-alive'} header has been added by Cypress. 
This is the error log being printed out by grpcwebproxy
```
ERRO[0215] finished streaming call with code Internal    error="rpc error: code = Internal 
desc = stream terminated by RST_STREAM with error code: PROTOCOL_ERROR" 
grpc.code=Internal grpc.method=Echo grpc.service=grpc.gateway.testing.EchoService grpc.start_time="2020-11-02T08:23:43+13:00" grpc.time_ms=0.345 span.kind=server system=grpc
```
## Verification

<!-- How you tested it? How do you know it works? -->
By comparing the requests sent through Chrome and Cypress, the only difference is the connection header and proxy-connection header. After drop the proxy-connection header, the grpcwebproxy forwarded the request to node server successfully and the cypress tests passed.
/assign 
