### PR TITLE
Catch exception thrown when cancelling fetch in grpc-web client

### DIFF
--- a/client/grpc-web/src/transports/http/fetch.ts
+++ b/client/grpc-web/src/transports/http/fetch.ts
@@ -37,7 +37,8 @@ class Fetch implements Transport {
     if (this.cancelled) {
       // If the request was cancelled before the first pump then cancel it here
       this.options.debug && debug("Fetch.pump.cancel at first pump");
-      this.reader.cancel();
+      this.reader.cancel().catch((e) =>
+          this.options.debug && debug("Fetch.pump.cancel caught", e));
       return;
     }
     this.reader.read()


### PR DESCRIPTION
```
grpc-web-client.umd.js:1 Uncaught (in promise) DOMException: The user aborted a request.
```

I'm seeing this log in the browser when cancelling a grpc-web request.
Since `reader.cancel()` returns a promise, I am guessing the cancellation is scheduled, and subsequently logged.

## Changes

Add a catch statement when aborting a fetch response reader.

## Verification

Verified from my local, I am assuming regressions will be checked via existing unit tests.

```
grpc-web-client.umd.js:1 onHeaders.gRPCStatus 16
grpc-web-client.umd.js:1 onHeaders.code 16
grpc-web-client.umd.js:1 onHeaders.gRPCMessage ["user doesn't exist"]
grpc-web-client.umd.js:1 rawOnHeaders e {headersMap: {…}}
pollEpic.ts:39 e {headersMap: {…}}
grpc-web-client.umd.js:1 rawOnError 16 user doesn't exist
grpc-web-client.umd.js:1 request.abort aborting request
grpc-web-client.umd.js:1 Fetch.abort.cancel before reader
grpc-web-client.umd.js:1 Fetch.pump.cancel at first pump
grpc-web-client.umd.js:1 Fetch.pump.cancel caught DOMException: The user aborted a request.
```