### PR TITLE
Fixed fetch abort behaviour for Edge 16+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ env:
     - BROWSER=chrome_52
     - BROWSER=chrome_43
     - BROWSER=chrome_41
-    # Edge does not support aborting fetch requests (documented known limitation in project README)
+    - BROWSER=edge16_win
+    # Edge < 16 does not support aborting fetch requests (documented known limitation in project README)
     - BROWSER=edge15_win DISABLE_ABORT_TESTS=true
     - BROWSER=edge14_win DISABLE_ABORT_TESTS=true
     - BROWSER=edge13_win DISABLE_ABORT_TESTS=true

--- a/client/grpc-web/docs/transport.md
+++ b/client/grpc-web/docs/transport.md
@@ -43,7 +43,7 @@ It's great that we have more than one choice when it comes to Web Browsers, howe
 
 * gRPC offers four categories of request: unary, server-streaming, client-streaming and bi-directional. Due to limitations of the Browser HTTP primitives (`fetch` and `XMLHttpRequest`), the HTTP/2-based transports provided by `@improbable-eng/grpc-web` can only support unary and server-streaming requests. Attempts to invoke either client-streaming or bi-directional endpoints will result in failure.
 * Older versions of Safari (<7) and all versions of Internet Explorer do not provide an efficient way to stream data from a server; this will result in the entire response of a gRPC client-stream being buffered into memory which can cause performance and stability issues for end-users. 
-* Microsoft Edge does not propagate the cancellation of requests to the server; which can result in memory/process leaks on your server. Track this issue for status.
+* Microsoft Edge (<16) does not propagate the cancellation of requests to the server; which can result in memory/process leaks on your server. Track [this issue](https://github.com/improbable-eng/grpc-web/issues/125) for status.
 
 Note that the [Socket-based Transports](#socket-based-transports) alleviate the above issues.
 

--- a/integration_test/browsers.ts
+++ b/integration_test/browsers.ts
@@ -49,6 +49,7 @@ function browser(browserName, browserVersion, os, osVersion) {
 // Browser versions that should not have any Fetch/XHR differences in functionality to other (tested) versions are
 // commented out.
 const browsers = {
+  edge16_win: browser("edge", "16", "Windows", "10"),
   edge15_win: browser("edge", "15", "Windows", "10"),
   edge14_win: browser("edge", "14", "Windows", "10"),
   edge13_win: browser('edge', "13", 'Windows', "10"),


### PR DESCRIPTION
Came across this issue whilst overhauling the testing CI and have pulled it out to leave that work independent of functional changes.

## Changes

* Moved the `AbortController.abort()` to before the `reader.cancel()` which appears to silently (on the client side) fix the server connection not being closed immediately.
* Added Edge 16 to browser test matrix

## Verification

* CI ran successfully
