### PR TITLE
Persist sauce connect proxy logs as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
       - run: << parameters.browser-params >> npm run test:integration-browsers:ci
       - store_test_results:
           path: ./integration_test/test-results
+      - store_artifacts:
+          path: ./integration_test/sauce-connect-proxy/logs
 workflows:
   version: 2
   test-workflow:

--- a/integration_test/run-with-tunnel.sh
+++ b/integration_test/run-with-tunnel.sh
@@ -4,7 +4,7 @@ set -x
 
 cd "$(dirname "$0")"
 
-mkdir -p sauce-connect-proxy
+mkdir -p sauce-connect-proxy/logs
 pushd sauce-connect-proxy
 
 wait_file() {
@@ -43,7 +43,7 @@ if [[ -z "${SC_SSL_BUMPING}" ]]; then
   $SAUCELABS_TUNNEL_PATH \
     -u $SAUCELABS_USERNAME \
     -k $SAUCELABS_ACCESS_KEY \
-    --logfile ./saucelabs-no-ssl-bump-logs \
+    --logfile ./logs/saucelabs-no-ssl-bump-logs \
     --pidfile ./saucelabs-no-ssl-bump-pid \
     --no-ssl-bump-domains testhost,corshost \
     --tunnel-identifier $SAUCELABS_TUNNEL_ID_NO_SSL_BUMP \
@@ -58,7 +58,7 @@ if [[ ! -z "${SC_SSL_BUMPING}" ]]; then
   $SAUCELABS_TUNNEL_PATH \
     -u $SAUCELABS_USERNAME \
     -k $SAUCELABS_ACCESS_KEY \
-    --logfile ./saucelabs-with-ssl-bump-logs \
+    --logfile ./logs/saucelabs-with-ssl-bump-logs \
     --pidfile ./saucelabs-with-ssl-bump-pid \
     --tunnel-identifier $SAUCELABS_TUNNEL_ID_WITH_SSL_BUMP \
     --readyfile $SAUCELABS_READY_FILE_WITH_SSL_BUMP \
@@ -104,12 +104,3 @@ popd
 
 # Run the specified commands
 $@
-
-# Output the logs from the Sauce Connect proxy
-cd "$(dirname "$0")"
-pushd sauce-connect-proxy
-echo "Printing SauceConnect no-ssl bump logs:"
-cat ./saucelabs-no-ssl-bump-logs || true
-echo "Printing SauceConnect with-ssl bump logs:"
-cat ./saucelabs-with-ssl-bump-logs || true
-popd


### PR DESCRIPTION
Some CI runs are failing due to contention on writing the log files to stdout. This change should mitigate that by persisting the logs as artifacts on CircleCI instead.

## Changes

* Store Sauce Connect Proxy (SauceLabs tunnel) logs as CircleCI artifacts

## Verification

* CI Run
