### PR TITLE
Fixed version numbers in package-lock.json

### DIFF
--- a/client/grpc-web/package-lock.json
+++ b/client/grpc-web/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@improbable-eng/grpc-web",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@improbable-eng/grpc-web",
-			"version": "0.13.0",
+			"version": "0.14.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"browser-headers": "^0.4.1"

--- a/integration_test/package-lock.json
+++ b/integration_test/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "grpc-web-integration-test",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "grpc-web-integration-test",
-			"version": "0.13.0",
+			"version": "0.14.0",
 			"license": "none",
 			"dependencies": {
 				"browser-headers": "^0.4.1",


### PR DESCRIPTION
## Changes

* Missing `package-lock.json` changes from #848