### PR TITLE
Fix /metrics, /debug/requests, /debug/events + additional flag for enabling those

### DIFF
--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -132,13 +132,14 @@ func buildDebugServer(wrappedGrpc *grpcweb.WrappedGrpcServer, metricsHandler htt
 		WriteTimeout: *flagHttpMaxWriteTimeout,
 		ReadTimeout:  *flagHttpMaxReadTimeout,
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			if req.URL.Path == "/metrics" {
+			switch req.URL.Path {
+			case "/metrics":
 				metricsHandler.ServeHTTP(resp, req)
-			} else if req.URL.Path == "/debug/requests" {
+			case "/debug/requests":
 				trace.Traces(resp, req)
-			} else if req.URL.Path == "/debug/events" {
+			case "/debug/events":
 				trace.Events(resp, req)
-			} else {
+			default:
 				wrappedGrpc.ServeHTTP(resp, req)
 			}
 		}),

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -45,7 +45,7 @@ var (
 	flagHttpMaxWriteTimeout = pflag.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = pflag.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
 
-	enableRequestDebug = pflag.Bool("enable_request_debug", false, "whether to enable (/debug/requests) and connection(/debug/events) monitoring; also controls prometheus monitoring (/monitoring)")
+	enableRequestDebug = pflag.Bool("enable_request_debug", false, "whether to enable (/debug/requests) and connection(/debug/events) monitoring; also controls prometheus monitoring (/metrics)")
 )
 
 func main() {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
/metrics and /debug/*  was not working in the several latest releases. I restored the functionality and added a flag to enable those

## Changes
- /metrics , /debug/requests, /debug/events manually added to the http debug server.
- 
<!-- Enumerate changes you made -->

## Verification

Manual testing weas performend to check that new handlers do not interfere with grpc request processing with websockets enabled and disabled. /debug/* pages were checked to be accessible only from localhost if enabled, /metrics is accessible from everywhere if enabled.

<!-- How you tested it? How do you know it works? -->