### PR TITLE
Add configuration support for nyhoor websocket read limit

### DIFF
--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -24,6 +24,7 @@ type options struct {
 	enableWebsockets               bool
 	websocketPingInterval          time.Duration
 	websocketOriginFunc            func(req *http.Request) bool
+	websocketReadLimit             int64
 	allowNonRootResources          bool
 	endpointsFunc                  *func() []string
 }
@@ -129,6 +130,15 @@ func WithWebsocketPingInterval(websocketPingInterval time.Duration) Option {
 func WithWebsocketOriginFunc(websocketOriginFunc func(req *http.Request) bool) Option {
 	return func(o *options) {
 		o.websocketOriginFunc = websocketOriginFunc
+	}
+}
+
+// WithWebsocketsMessageReadLimit sets the maximum message read limit on the underlying websocket.
+//
+// The default message read limit is 32769 bytes
+func WithWebsocketsMessageReadLimit(websocketReadLimit int64) Option {
+	return func(o *options) {
+		o.websocketReadLimit = websocketReadLimit
 	}
 }
 

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -41,6 +41,7 @@ var (
 
 	useWebsockets         = pflag.Bool("use_websockets", false, "whether to use beta websocket transport layer")
 	websocketPingInterval = pflag.Duration("websocket_ping_interval", 0, "whether to use websocket keepalive pinging. Only used when using websockets. Configured interval must be >= 1s.")
+	websocketReadLimit    = pflag.Int64("websocket_read_limit", 0, "sets the maximum message read limit on the underlying websocket. The default message read limit is 32769 bytes.")
 
 	flagHttpMaxWriteTimeout = pflag.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = pflag.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
@@ -84,6 +85,10 @@ func main() {
 		if *websocketPingInterval >= time.Second {
 			logrus.Infof("websocket keepalive pinging enabled, the timeout interval is %s", websocketPingInterval.String())
 		}
+		if *websocketReadLimit > 0 {
+			options = append(options, grpcweb.WithWebsocketsMessageReadLimit(*websocketReadLimit))
+		}
+
 		options = append(
 			options,
 			grpcweb.WithWebsocketPingInterval(*websocketPingInterval),


### PR DESCRIPTION
Adding support to configure the underlying nyhoor websocket read limit.

## Changes

The changes are minimal

1. Add new configuration property `WithWebsocketsMessageReadLimit`
2. Apply this read limit to the websocket if it is configured, otherwise do nothing. In this case the default limit is used.

## Verification

The codes successfully builds and works in my local environment. 
