### PR TITLE
updated documentation to accurately reflect the existing API for unary call aborting

### DIFF
--- a/client/grpc-web/README.md
+++ b/client/grpc-web/README.md
@@ -45,11 +45,11 @@ grpc.unary(BookService.GetBook, {
 });
 ```
 
-* Requests can be aborted/cancelled before they complete:
+* Requests can be aborted/closed before they complete:
 
 ```javascript
 const request = grpc.unary(BookService.GetBook, { ... });
-request.cancel();
+request.close();
 ```
 
 ## Available Request Functions


### PR DESCRIPTION
The current documentation states that `.cancel()` is the method for aborting a unary call—it appears as though both `unary` and `invoke` actually use `.close()`.

## Changes

This PR updates the documentation to accurately reflect the API in source code.

## Verification

Viewing source code and using TypeScript intellisense.
