### PR TITLE
[grpcweb/go] Allow Access-Control-Max-Age customization

### DIFF
--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -118,6 +118,17 @@ endpoints (e.g. for proxying).
 The default behaviour is `true`, i.e. only allows CORS requests for registered
 endpoints.
 
+#### func  WithCorsMaxAge
+
+```go
+func WithCorsMaxAge(maxAge time.Duration) Option
+```
+WithCorsMaxAge customize the `Access-Control-Max-Age: <delta-seconds>` header
+which controls the cache age for a CORS preflight request that checks to see if
+the CORS protocol is understood.
+
+The default age is 10 minutes.
+
 #### func  WithEndpointsFunc
 
 ```go

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -14,12 +14,14 @@ var (
 		corsForRegisteredEndpointsOnly: true,
 		originFunc:                     func(origin string) bool { return false },
 		allowNonRootResources:          false,
+		corsMaxAge:                     10 * time.Minute,
 	}
 )
 
 type options struct {
 	allowedRequestHeaders          []string
 	corsForRegisteredEndpointsOnly bool
+	corsMaxAge                     time.Duration
 	originFunc                     func(origin string) bool
 	enableWebsockets               bool
 	websocketPingInterval          time.Duration
@@ -65,6 +67,16 @@ func WithOriginFunc(originFunc func(origin string) bool) Option {
 func WithCorsForRegisteredEndpointsOnly(onlyRegistered bool) Option {
 	return func(o *options) {
 		o.corsForRegisteredEndpointsOnly = onlyRegistered
+	}
+}
+
+// WithCorsMaxAge customize the `Access-Control-Max-Age: <delta-seconds>` header which controls the cache age for a CORS preflight
+// request that checks to see if the CORS protocol is understood.
+//
+// The default age is 10 minutes.
+func WithCorsMaxAge(maxAge time.Duration) Option {
+	return func(o *options) {
+		o.corsMaxAge = maxAge
 	}
 }
 

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -70,9 +70,9 @@ func wrapGrpc(options []Option, handler http.Handler, endpointsFunc func() []str
 	corsWrapper := cors.New(cors.Options{
 		AllowOriginFunc:  opts.originFunc,
 		AllowedHeaders:   allowedHeaders,
-		ExposedHeaders:   nil,                                 // make sure that this is *nil*, otherwise the WebResponse overwrite will not work.
-		AllowCredentials: true,                                // always allow credentials, otherwise :authorization headers won't work
-		MaxAge:           int(10 * time.Minute / time.Second), // make sure pre-flights don't happen too often (every 5s for Chromium :( )
+		ExposedHeaders:   nil,  // make sure that this is *nil*, otherwise the WebResponse overwrite will not work.
+		AllowCredentials: true, // always allow credentials, otherwise :authorization headers won't work
+		MaxAge:           int(opts.corsMaxAge.Seconds()),
 	})
 	websocketOriginFunc := opts.websocketOriginFunc
 	if websocketOriginFunc == nil {
@@ -120,7 +120,7 @@ func (w *WrappedGrpcServer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 				return
 			}
 		}
-		resp.WriteHeader(403)
+		resp.WriteHeader(http.StatusForbidden)
 		_, _ = resp.Write(make([]byte, 0))
 		return
 	}


### PR DESCRIPTION
The change gives the ability to control the cache age of the preflight
requests to Cross-Origin resources.

The default value remains 10 minutes.
