### PR TITLE
Limit parallelism of browser tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
       browser-params:
         type: string
     executor: test-executor
+    parallelism: 5
     steps:
       - checkout
       # Attaches the workspace from the previous step to retrieve the built assets for the tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       browser-params:
         type: string
     executor: test-executor
-    parallelism: 5
+    parallelism: 1
     steps:
       - checkout
       # Attaches the workspace from the previous step to retrieve the built assets for the tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ workflows:
                 - BROWSER=edge88_win
                 - BROWSER=edge16_win
           requires:
-            - browser-tests-first
+            - browser-tests
       - browser-tests:
           name: browser-tests-third
           matrix:
@@ -128,7 +128,7 @@ workflows:
                 - BROWSER=safari13_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=safari12_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
           requires:
-            - browser-tests-second
+            - browser-tests
       - browser-tests:
           name: browser-tests-fourth
           matrix:
@@ -140,7 +140,7 @@ workflows:
                 - BROWSER=safari8 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=ie11_win DISABLE_WEBSOCKET_TESTS=true
           requires:
-            - browser-tests-third
+            - browser-tests
       - browser-tests:
           name: browser-tests-fifth
           matrix:
@@ -148,4 +148,4 @@ workflows:
               browser-params:
                 - BROWSER=nodejs
           requires:
-            - browser-tests-fourth
+            - browser-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
       browser-params:
         type: string
     executor: test-executor
-    parallelism: 1
     steps:
       - checkout
       # Attaches the workspace from the previous step to retrieve the built assets for the tests
@@ -91,7 +90,11 @@ workflows:
   test-workflow:
     jobs:
       - initial-unit-test-lint-prebuild
-      - browser-tests:
+      # Split browser test matrix into separate jobs to keep parallelism
+      # to a maximum of 5 jobs, the maximum number of parallel jobs
+      # our SauceLabs configuration allows.
+      - browser-tests-1:
+          name: browser-tests
           matrix:
             parameters:
               browser-params:
@@ -100,21 +103,49 @@ workflows:
                 - BROWSER=firefox38_win DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=chrome_89
                 - BROWSER=chrome_52
+          requires:
+            - initial-unit-test-lint-prebuild
+      - browser-tests-2:
+          name: browser-tests
+          matrix:
+            parameters:
+              browser-params:
                 - BROWSER=chrome_43
                 - BROWSER=chrome_42
                 - BROWSER=chrome_41
                 - BROWSER=edge88_win
                 - BROWSER=edge16_win
+          requires:
+            - browser-tests-1
+      - browser-tests-3:
+          name: browser-tests
+          matrix:
+            parameters:
+              browser-params:
                 - BROWSER=edge14_win
                 - BROWSER=edge13_win
                 - BROWSER=safari14 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=safari13_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=safari12_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
+          requires:
+            - browser-tests-2
+      - browser-tests-4:
+          name: browser-tests
+          matrix:
+            parameters:
+              browser-params:
                 - BROWSER=safari11_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=safari10_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=safari9_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=safari8 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=ie11_win DISABLE_WEBSOCKET_TESTS=true
+          requires:
+            - browser-tests-3
+      - browser-tests-5:
+          name: browser-tests
+          matrix:
+            parameters:
+              browser-params:
                 - BROWSER=nodejs
           requires:
-            - initial-unit-test-lint-prebuild
+            - browser-tests-4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ workflows:
       # to a maximum of 5 jobs, the maximum number of parallel jobs
       # our SauceLabs configuration allows.
       - browser-tests:
-          name: browser-tests-1
+          name: browser-tests-first
           matrix:
             parameters:
               browser-params:
@@ -106,7 +106,7 @@ workflows:
           requires:
             - initial-unit-test-lint-prebuild
       - browser-tests:
-          name: browser-tests-2
+          name: browser-tests-second
           matrix:
             parameters:
               browser-params:
@@ -116,9 +116,9 @@ workflows:
                 - BROWSER=edge88_win
                 - BROWSER=edge16_win
           requires:
-            - browser-tests-1
+            - browser-tests-first
       - browser-tests:
-          name: browser-tests-3
+          name: browser-tests-third
           matrix:
             parameters:
               browser-params:
@@ -128,9 +128,9 @@ workflows:
                 - BROWSER=safari13_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=safari12_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
           requires:
-            - browser-tests-2
+            - browser-tests-second
       - browser-tests:
-          name: browser-tests-4
+          name: browser-tests-fourth
           matrix:
             parameters:
               browser-params:
@@ -140,12 +140,12 @@ workflows:
                 - BROWSER=safari8 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=ie11_win DISABLE_WEBSOCKET_TESTS=true
           requires:
-            - browser-tests-3
+            - browser-tests-third
       - browser-tests:
-          name: browser-tests-5
+          name: browser-tests-fifth
           matrix:
             parameters:
               browser-params:
                 - BROWSER=nodejs
           requires:
-            - browser-tests-4
+            - browser-tests-fourth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,8 @@ workflows:
       # Split browser test matrix into separate jobs to keep parallelism
       # to a maximum of 5 jobs, the maximum number of parallel jobs
       # our SauceLabs configuration allows.
-      - browser-tests-1:
-          name: browser-tests
+      - browser-tests:
+          name: browser-tests-1
           matrix:
             parameters:
               browser-params:
@@ -105,8 +105,8 @@ workflows:
                 - BROWSER=chrome_52
           requires:
             - initial-unit-test-lint-prebuild
-      - browser-tests-2:
-          name: browser-tests
+      - browser-tests:
+          name: browser-tests-2
           matrix:
             parameters:
               browser-params:
@@ -117,8 +117,8 @@ workflows:
                 - BROWSER=edge16_win
           requires:
             - browser-tests-1
-      - browser-tests-3:
-          name: browser-tests
+      - browser-tests:
+          name: browser-tests-3
           matrix:
             parameters:
               browser-params:
@@ -129,8 +129,8 @@ workflows:
                 - BROWSER=safari12_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
           requires:
             - browser-tests-2
-      - browser-tests-4:
-          name: browser-tests
+      - browser-tests:
+          name: browser-tests-4
           matrix:
             parameters:
               browser-params:
@@ -141,8 +141,8 @@ workflows:
                 - BROWSER=ie11_win DISABLE_WEBSOCKET_TESTS=true
           requires:
             - browser-tests-3
-      - browser-tests-5:
-          name: browser-tests
+      - browser-tests:
+          name: browser-tests-5
           matrix:
             parameters:
               browser-params:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,8 @@ workflows:
       # to a maximum of 5 jobs, the maximum number of parallel jobs
       # our SauceLabs configuration allows.
       - browser-tests:
-          name: browser-tests-first
           matrix:
+            alias: browser-tests-first
             parameters:
               browser-params:
                 - BROWSER=firefox86_win
@@ -106,8 +106,8 @@ workflows:
           requires:
             - initial-unit-test-lint-prebuild
       - browser-tests:
-          name: browser-tests-second
           matrix:
+            alias: browser-tests-second
             parameters:
               browser-params:
                 - BROWSER=chrome_43
@@ -116,10 +116,10 @@ workflows:
                 - BROWSER=edge88_win
                 - BROWSER=edge16_win
           requires:
-            - browser-tests
+            - browser-tests-first
       - browser-tests:
-          name: browser-tests-third
           matrix:
+            alias: browser-tests-third
             parameters:
               browser-params:
                 - BROWSER=edge14_win
@@ -128,10 +128,10 @@ workflows:
                 - BROWSER=safari13_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=safari12_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
           requires:
-            - browser-tests
+            - browser-tests-second
       - browser-tests:
-          name: browser-tests-fourth
           matrix:
+            alias: browser-tests-fourth
             parameters:
               browser-params:
                 - BROWSER=safari11_1 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
@@ -140,12 +140,11 @@ workflows:
                 - BROWSER=safari8 SC_SSL_BUMPING=true DISABLE_WEBSOCKET_TESTS=true
                 - BROWSER=ie11_win DISABLE_WEBSOCKET_TESTS=true
           requires:
-            - browser-tests
+            - browser-tests-third
       - browser-tests:
-          name: browser-tests-fifth
           matrix:
             parameters:
               browser-params:
                 - BROWSER=nodejs
           requires:
-            - browser-tests
+            - browser-tests-fourth


### PR DESCRIPTION
Sauce labs only allow 5 tests to run concurrently, so limit parallelism to avoid having to manually rerun tests.
