### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/client/grpc-web-react-native-transport/src/index.ts
+++ b/client/grpc-web-react-native-transport/src/index.ts
@@ -85,7 +85,7 @@ class XHR implements grpc.Transport {
 
   protected onProgressEvent() {
     this.options.debug && debug("XHR.onProgressEvent.length: ", this.xhr.response.length);
-    const rawText = this.xhr.response.substr(this.index);
+    const rawText = this.xhr.response.slice(this.index);
     this.index = this.xhr.response.length;
     const asArrayBuffer = stringToArrayBuffer(rawText);
     detach(() => {

--- a/client/grpc-web/src/transports/http/xhr.ts
+++ b/client/grpc-web/src/transports/http/xhr.ts
@@ -33,7 +33,7 @@ export class XHR implements Transport {
 
   onProgressEvent() {
     this.options.debug && debug("XHR.onProgressEvent.length: ", this.xhr.response.length);
-    const rawText = this.xhr.response.substr(this.index);
+    const rawText = this.xhr.response.slice(this.index);
     this.index = this.xhr.response.length;
     const asArrayBuffer = stringToArrayBuffer(rawText);
     this.options.onChunk(asArrayBuffer);

--- a/client/grpc-web/src/transports/websocket/websocket.ts
+++ b/client/grpc-web/src/transports/websocket/websocket.ts
@@ -87,10 +87,10 @@ function websocketRequest(options: TransportOptions): Transport {
 }
 
 function constructWebSocketAddress(url: string) {
-  if (url.substr(0, 8) === "https://") {
-    return `wss://${url.substr(8)}`;
-  } else if (url.substr(0, 7) === "http://") {
-    return `ws://${url.substr(7)}`;
+  if (url.slice(0, 8) === "https://") {
+    return `wss://${url.slice(8)}`;
+  } else if (url.slice(0, 7) === "http://") {
+    return `ws://${url.slice(7)}`;
   }
   throw new Error("Websocket transport constructed with non-https:// or http:// host.");
 }


### PR DESCRIPTION
## Changes

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Verification

I have checked the return of each statement to make sure it's still the same as before
