### PR TITLE
Server websocket implementation should allow, ignore other subprotocols

### DIFF
--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -286,7 +286,7 @@ the "content-type" is "application/grpc-web" and that the method is POST.
 func (w *WrappedGrpcServer) IsGrpcWebSocketRequest(req *http.Request) bool
 ```
 IsGrpcWebSocketRequest determines if a request is a gRPC-Web request by checking
-that the "Sec-Websocket-Protocol" header value is "grpc-websockets"
+that the "Sec-Websocket-Protocol" header value contains "grpc-websockets"
 
 #### func (*WrappedGrpcServer) ServeHTTP
 

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -135,19 +135,19 @@ func (w *WrappedGrpcServer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 // IsGrpcWebSocketRequest determines if a request is a gRPC-Web request by checking that the "Sec-Websocket-Protocol"
 // header value contains "grpc-websockets"
 func (w *WrappedGrpcServer) IsGrpcWebSocketRequest(req *http.Request) bool {
-    if strings.ToLower(req.Header.Get("Upgrade")) != "websocket" {
-        return false
-    }
+	if strings.ToLower(req.Header.Get("Upgrade")) != "websocket" {
+		return false
+	}
 
-    for _, subproto := range req.Header["Sec-Websocket-Protocol"] {
-        for _, token := range strings.Split(subproto, ",") {
-            token = strings.TrimSpace(token)
-            if strings.EqualFold(token, "grpc-websockets") {
-                return true
-            }
-        }
-    }
-    return false
+	for _, subproto := range req.Header["Sec-Websocket-Protocol"] {
+		for _, token := range strings.Split(subproto, ",") {
+			token = strings.TrimSpace(token)
+			if strings.EqualFold(token, "grpc-websockets") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // HandleGrpcWebRequest takes a HTTP request that is assumed to be a gRPC-Web request and wraps it with a compatibility

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -139,7 +139,7 @@ func (w *WrappedGrpcServer) IsGrpcWebSocketRequest(req *http.Request) bool {
 		return false
 	}
 
-	for _, subproto := range req.Header["Sec-Websocket-Protocol"] {
+	for _, subproto := range req.Header.Values("Sec-Websocket-Protocol") {
 		for _, token := range strings.Split(subproto, ",") {
 			token = strings.TrimSpace(token)
 			if strings.EqualFold(token, "grpc-websockets") {

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -133,9 +133,21 @@ func (w *WrappedGrpcServer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 }
 
 // IsGrpcWebSocketRequest determines if a request is a gRPC-Web request by checking that the "Sec-Websocket-Protocol"
-// header value is "grpc-websockets"
+// header value contains "grpc-websockets"
 func (w *WrappedGrpcServer) IsGrpcWebSocketRequest(req *http.Request) bool {
-	return strings.ToLower(req.Header.Get("Upgrade")) == "websocket" && strings.ToLower(req.Header.Get("Sec-Websocket-Protocol")) == "grpc-websockets"
+    if strings.ToLower(req.Header.Get("Upgrade")) != "websocket" {
+        return false
+    }
+
+    for _, subproto := range req.Header["Sec-Websocket-Protocol"] {
+        for _, token := range strings.Split(subproto, ",") {
+            token = strings.TrimSpace(token)
+            if strings.EqualFold(token, "grpc-websockets") {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 // HandleGrpcWebRequest takes a HTTP request that is assumed to be a gRPC-Web request and wraps it with a compatibility


### PR DESCRIPTION
Correctly reads all Sec-Websocket-Protocol headers and reads all values
in those headers, and only succeeds if the expected subprotcol value of
"grpc-websockets" is present. This implementation roughly mirrors what
the nhooyr.io/websocket Accept() method does, with a few
simplifications.

Fixes #1111

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Updated `IsGrpcWebSocketRequest()` to allow for multiple protocol headers and values, but still only succeeds if the expected value `grpc-websockets` is present. Uses `strings.EqualFold` in place of `strings.toLower` and a `==` check, as this is a more flexible check, and reflects the underlying nhooyr.io/websockets implementation.

## Verification

* Tested with a lightly modified websocket.ts transport, which advertises an alternative subprotocol.
* Tested with a multiplex-capable websocket transport, which can fall back to the existing websocket transport in case the server doesn't also support multiplex.
