### PR TITLE
Add websocket compression mode option

### DIFF
--- a/go/grpcweb/DOC.md
+++ b/go/grpcweb/DOC.md
@@ -165,6 +165,15 @@ The default behaviour is to deny all requests from remote origins.
 The relevant CORS pre-flight docs:
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
 
+#### func  WithWebsocketCompressionMode
+
+```go
+func WithWebsocketCompressionMode(compressionMode websocket.CompressionMode) Option
+```
+WithWebsocketCompressionMode sets compression mode for websocket requests
+
+The default mode is CompressionNoContextTakeover
+
 #### func  WithWebsocketOriginFunc
 
 ```go

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -5,8 +5,9 @@ package grpcweb
 
 import (
 	"net/http"
-	"nhooyr.io/websocket"
 	"time"
+
+	"nhooyr.io/websocket"
 )
 
 var (

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -5,6 +5,7 @@ package grpcweb
 
 import (
 	"net/http"
+	"nhooyr.io/websocket"
 	"time"
 )
 
@@ -15,6 +16,7 @@ var (
 		originFunc:                     func(origin string) bool { return false },
 		allowNonRootResources:          false,
 		corsMaxAge:                     10 * time.Minute,
+		websocketCompressionMode:       websocket.CompressionNoContextTakeover,
 	}
 )
 
@@ -27,6 +29,7 @@ type options struct {
 	websocketPingInterval          time.Duration
 	websocketOriginFunc            func(req *http.Request) bool
 	websocketReadLimit             int64
+	websocketCompressionMode       websocket.CompressionMode
 	allowNonRootResources          bool
 	endpointsFunc                  *func() []string
 }
@@ -164,5 +167,14 @@ func WithWebsocketsMessageReadLimit(websocketReadLimit int64) Option {
 func WithAllowNonRootResource(allowNonRootResources bool) Option {
 	return func(o *options) {
 		o.allowNonRootResources = allowNonRootResources
+	}
+}
+
+// WithWebsocketCompressionMode sets compression mode for websocket requests
+//
+// The default mode is CompressionNoContextTakeover
+func WithWebsocketCompressionMode(compressionMode websocket.CompressionMode) Option {
+	return func(o *options) {
+		o.websocketCompressionMode = compressionMode
 	}
 }

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -169,6 +169,7 @@ func (w *WrappedGrpcServer) HandleGrpcWebsocketRequest(resp http.ResponseWriter,
 	wsConn, err := websocket.Accept(resp, req, &websocket.AcceptOptions{
 		InsecureSkipVerify: true, // managed by ServeHTTP
 		Subprotocols:       []string{"grpc-websockets"},
+		CompressionMode:    w.opts.websocketCompressionMode,
 	})
 	if err != nil {
 		grpclog.Errorf("Unable to upgrade websocket request: %v", err)

--- a/go/grpcwebproxy/README.md
+++ b/go/grpcwebproxy/README.md
@@ -68,6 +68,18 @@ $GOPATH/bin/grpcwebproxy \
     --use_websockets
 ```
 
+### Changing Websocket Compression
+By default, websocket compression is used as `no context takover`. To override compression type, use the `--websocket_compression_mode` option.
+Available options are `no_context_takeover`, `context_takeover`, `disabled`. Websocket compression types are described in [RFC 7692](https://datatracker.ietf.org/doc/html/rfc7692).
+
+For example, for disabling websocket compression run the following:
+```
+$GOPATH/bin/grpcwebproxy \
+    --backend_addr=localhost:9090 \
+    --use_websockets \
+    --websocket_compression_mode=disabled
+```
+
 ### Changing the Maximum Receive Message Size
 
 By default, grpcwebproxy will limit the message size that the backend sends to the client. This is currently 4MB.

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -6,10 +6,11 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" // register in DefaultServerMux
-	"nhooyr.io/websocket"
 	"os"
 	"sync"
 	"time"
+
+	"nhooyr.io/websocket"
 
 	"crypto/tls"
 

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" // register in DefaultServerMux
+	"nhooyr.io/websocket"
 	"os"
 	"sync"
 	"time"
@@ -40,9 +41,10 @@ var (
 	runHttpServer = pflag.Bool("run_http_server", true, "whether to run HTTP server")
 	runTlsServer  = pflag.Bool("run_tls_server", true, "whether to run TLS server")
 
-	useWebsockets         = pflag.Bool("use_websockets", false, "whether to use beta websocket transport layer")
-	websocketPingInterval = pflag.Duration("websocket_ping_interval", 0, "whether to use websocket keepalive pinging. Only used when using websockets. Configured interval must be >= 1s.")
-	websocketReadLimit    = pflag.Int64("websocket_read_limit", 0, "sets the maximum message read limit on the underlying websocket. The default message read limit is 32769 bytes.")
+	useWebsockets            = pflag.Bool("use_websockets", false, "whether to use beta websocket transport layer")
+	websocketPingInterval    = pflag.Duration("websocket_ping_interval", 0, "whether to use websocket keepalive pinging. Only used when using websockets. Configured interval must be >= 1s.")
+	websocketReadLimit       = pflag.Int64("websocket_read_limit", 0, "sets the maximum message read limit on the underlying websocket. The default message read limit is 32769 bytes.")
+	websocketCompressionMode = pflag.String("websocket_compression_mode", "no_context_takeover", "set compression mode for websocket. Values are no_context_takeover (, context_takeover, disabled. The default value is no_context_takeover.")
 
 	flagHttpMaxWriteTimeout = pflag.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = pflag.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
@@ -99,6 +101,23 @@ func main() {
 		options = append(
 			options,
 			grpcweb.WithWebsocketPingInterval(*websocketPingInterval),
+		)
+
+		var compressionMode websocket.CompressionMode
+		switch *websocketCompressionMode {
+		case "no_context_takeover":
+			compressionMode = websocket.CompressionNoContextTakeover
+		case "context_takeover":
+			compressionMode = websocket.CompressionContextTakeover
+		case "disabled":
+			compressionMode = websocket.CompressionDisabled
+		default:
+			logrus.Fatalf("unknwon param for websocket compression mode: %s", *websocketCompressionMode)
+		}
+
+		options = append(
+			options,
+			grpcweb.WithWebsocketCompressionMode(compressionMode),
 		)
 	}
 


### PR DESCRIPTION
## Changes

1. Add WebsocketCompressionMode option to WrappedGrpcServer for managing websocket compression
2. Add usage example to grpcwebproxy

## Verification
The motivation: we encountered some websocket problems with IOS 15 which were fixed by disabling compressing.
I'd like to have an option for managing websocket compression depending on the application needs.
I've tested disabling websocket compression in a separate fork
