### PR TITLE
Add documentation to show client-side/bi-directional streaming using websockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ It is very important to note that the gRPC-Web spec currently *does not support 
 
 This, however, is useful for a lot of frontend functionality.
 
+*Note that `@improbable-eng/grpc-web` provides a built-in [websocket](./client/grpc-web/docs/websocket.md) transport that can support client-side/bi-directional streaming RPCs.*
+
 ## Status
 
 The code here is `alpha` quality. It is being used for a subset of Improbable's frontend single-page apps in production.

--- a/client/grpc-web/README.md
+++ b/client/grpc-web/README.md
@@ -92,3 +92,4 @@ Refer to [grpc-web-node-http-transport](https://www.npmjs.com/package/@improbabl
 * [Code Generation](docs/code-generation.md)
 * [Concepts](docs/concepts.md)
 * [Transport](docs/transport.md)
+* [Client-side streaming](docs/websocket.md)

--- a/client/grpc-web/docs/websocket.md
+++ b/client/grpc-web/docs/websocket.md
@@ -1,6 +1,6 @@
 # Client-side streaming over websocket
 
-Due to the [limitations](./transport.md#http/2-based-transports) of HTTP/2 based transports in browsers, they cannot support client-side/bi-directional streaming. `@improbable-eng/grpc-web` provides a built-in [websocket](./transport.md#socket-based-transports) transport that can be used to alleviate this issue.
+Due to the [limitations](./transport.md#http2-based-transports) of HTTP/2 based transports in browsers, they cannot support client-side/bi-directional streaming. `@improbable-eng/grpc-web` provides a built-in [websocket](./transport.md#socket-based-transports) transport that can be used to alleviate this issue.
 
 ## Enabling at the client side
 

--- a/client/grpc-web/docs/websocket.md
+++ b/client/grpc-web/docs/websocket.md
@@ -1,6 +1,6 @@
 # Client-side streaming over websocket
 
-Due to the [limitations](./transport.md#http2-based-transports) of HTTP/2 based transports in browsers, they cannot support client-side/bi-directional streaming. `@improbable-eng/grpc-web` provides a built-in [websocket](./transport.md#socket-based-transports) transport that can be used to alleviate this issue.
+Due to the [limitations](./transport.md#http2-based-transports) of HTTP/2 based transports in browsers, they cannot support client-side/bi-directional streaming. `@improbable-eng/grpc-web` provides a built-in [websocket](./transport.md#socket-based-transports) transport that alleviates this issue.
 
 ## Enabling at the client side
 

--- a/client/grpc-web/docs/websocket.md
+++ b/client/grpc-web/docs/websocket.md
@@ -1,0 +1,17 @@
+# Client-side streaming over websocket
+
+Due to the [limitations](./transport.md#http/2-based-transports) of HTTP/2 based transports in browsers, they cannot support client-side/bi-directional streaming. `@improbable-eng/grpc-web` provides a built-in [websocket](./transport.md#socket-based-transports) transport that can be used to alleviate this issue.
+
+## Enabling at the client side
+
+To enable websocket communication at the client side, `WebsocketTransport` needs to be configured. See [this](./transport.md#specifying-transports) on how to configure a transport in your application.
+
+## Enabling at the server side
+
+### grpcwebproxy
+
+If you're using `grpcwebproxy` to front your gRPC server, see [this](../../../go/grpcwebproxy/README.md#enabling-websocket-transport).
+
+### grpcweb
+
+If you're using `grpcweb` module as a wrapper around your gRPC-Go server, see [this](../../../go/grpcweb#func--withwebsockets).


### PR DESCRIPTION
## Changes

The main and client/grpc-web Readme files do not contain info on the usage of websocket transport for supporting client-side or bi-directional streaming RPCs.

1. This info has been added in both the Readme files.

2. A new doc is created that explains how to configure websockets at the client and server side.


