### PR TITLE
Notify users that this repo is in maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![quality: alpha](https://img.shields.io/badge/quality-alpha-orange.svg)](#status)
 [![Slack](https://img.shields.io/badge/join%20slack-%23grpc--web-brightgreen.svg)](https://join.slack.com/t/improbable-eng/shared_invite/enQtMzQ1ODcyMzQ5MjM4LWY5ZWZmNGM2ODc5MmViNmQ3ZTA3ZTY3NzQwOTBlMTkzZmIxZTIxODk0OWU3YjZhNWVlNDU3MDlkZGViZjhkMjc)
 
+> Please note that this repo is in maintenance mode, and we recommend users migrate to the official grpc-web client: https://github.com/grpc/grpc-web.
+
 [gRPC](http://www.grpc.io/) is a modern, [HTTP2](https://hpbn.co/http2/)-based protocol, that provides RPC semantics using the strongly-typed *binary* data format of [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview) across multiple languages (C++, C#, Golang, Java, Python, NodeJS, ObjectiveC, etc.)
 
 [gRPC-Web](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md) is a cutting-edge spec that enables invoking gRPC services from *modern* browsers.


### PR DESCRIPTION
Hey there, I've recently been trying to figure out the open source proto infrastructure, which in itself has been pretty hard to navigate -- but I noticed that @johanbrandhorst has commented on multiple recent issues with this quote.

> Please note that this repo is in maintenance mode, and we recommend users migrate to the official grpc-web client: https://github.com/grpc/grpc-web.

It's interesting that it doesn't seem to suggest this anywhere on the README, and I didn't really figure out that this was the suggested path (by the maintainers of this repo) until digging deeper while debugging some stuff. In the end, it's totally up to you, but it seems to me like this would be something useful to put at the top of the README, so this PR just copy-pastes that quote (feel free to adjust formatting / wording as desired).

Cheers, and thanks for your work.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
