### PR TITLE
Add WithExposedResponseHeaders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/improbable-eng/grpc-web
+module github.com/roboslone/grpc-web
 
 go 1.16
 

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -25,13 +25,17 @@ type grpcWebResponse struct {
 
 	// The standard "application/grpc" content-type will be replaced with this.
 	contentType string
+
+	// Values appended to "Access-Control-Expose-Headers" response header.
+	exposedHeaders []string
 }
 
-func newGrpcWebResponse(resp http.ResponseWriter, isTextFormat bool) *grpcWebResponse {
+func newGrpcWebResponse(resp http.ResponseWriter, isTextFormat bool, exposedHeaders []string) *grpcWebResponse {
 	g := &grpcWebResponse{
-		headers:     make(http.Header),
-		wrapped:     resp,
-		contentType: grpcWebContentType,
+		headers:        make(http.Header),
+		wrapped:        resp,
+		contentType:    grpcWebContentType,
+		exposedHeaders: exposedHeaders,
 	}
 	if isTextFormat {
 		g.wrapped = newBase64ResponseWriter(g.wrapped)
@@ -79,8 +83,9 @@ func (w *grpcWebResponse) prepareHeaders() {
 	)
 	responseHeaderKeys := headerKeys(wh)
 	responseHeaderKeys = append(responseHeaderKeys, "grpc-status", "grpc-message")
+	responseHeaderKeys = append(responseHeaderKeys, w.exposedHeaders...)
 	wh.Set(
-		http.CanonicalHeaderKey("access-control-expose-headers"),
+		"access-control-expose-headers",
 		strings.Join(responseHeaderKeys, ", "),
 	)
 }

--- a/go/grpcweb/options.go
+++ b/go/grpcweb/options.go
@@ -23,6 +23,7 @@ var (
 
 type options struct {
 	allowedRequestHeaders          []string
+	exposedResponseHeaders         []string
 	corsForRegisteredEndpointsOnly bool
 	corsMaxAge                     time.Duration
 	originFunc                     func(origin string) bool
@@ -118,6 +119,12 @@ func WithEndpointsFunc(endpointsFunc func() []string) Option {
 func WithAllowedRequestHeaders(headers []string) Option {
 	return func(o *options) {
 		o.allowedRequestHeaders = headers
+	}
+}
+
+func WithExposedResponseHeaders(headers []string) Option {
+	return func(o *options) {
+		o.exposedResponseHeaders = headers
 	}
 }
 

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -155,7 +155,7 @@ func (w *WrappedGrpcServer) IsGrpcWebSocketRequest(req *http.Request) bool {
 // with the gRPC-Web protocol.
 func (w *WrappedGrpcServer) HandleGrpcWebRequest(resp http.ResponseWriter, req *http.Request) {
 	intReq, isTextFormat := hackIntoNormalGrpcRequest(req)
-	intResp := newGrpcWebResponse(resp, isTextFormat)
+	intResp := newGrpcWebResponse(resp, isTextFormat, w.opts.exposedResponseHeaders)
 	intReq.URL.Path = w.endpointFunc(intReq)
 	w.handler.ServeHTTP(intResp, intReq)
 	intResp.finishRequest(req)


### PR DESCRIPTION
## Changes

Added `WithExposedResponseHeaders` option to allow exposing custom headers (e.g. `x-b3-traceid` for Jaeger tracing).

## Verification

Added `TestExposedHeaders`.
